### PR TITLE
test: Configure H2 In-Memory Database for Isolated Integration Tests

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,6 +54,13 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.h2database/h2 -->
+		<dependency>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
+			<version>2.3.232</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/test/java/io/github/joaomnz/bettracker/BettrackerApplicationTests.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/BettrackerApplicationTests.java
@@ -2,7 +2,9 @@ package io.github.joaomnz.bettracker;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class BettrackerApplicationTests {
 

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=none
+spring.sql.init.mode=always
+spring.sql.init.schema-locations=classpath:schema.sql
+spring.sql.init.data-locations=classpath:data.sql
+
+logging.level.org.springframework.security=DEBUG
+logging.level.org.springframework.web=DEBUG

--- a/backend/src/test/resources/data.sql
+++ b/backend/src/test/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO bettor(name, email, password) values('João', 'bettracker@hotmail.com', 'bettracker');

--- a/backend/src/test/resources/schema.sql
+++ b/backend/src/test/resources/schema.sql
@@ -1,0 +1,92 @@
+-- ========= ENUMERATIONS =========
+CREATE TYPE bettor_type AS ENUM ('FREE', 'PREMIUM');
+CREATE TYPE transaction_type AS ENUM ('DEPOSIT', 'WITHDRAWAL');
+CREATE TYPE bet_status AS ENUM ('PENDING', 'WON', 'LOST', 'PUSH', 'HALF_WON', 'HALF_LOST', 'CASHOUT', 'VOID');
+CREATE TYPE stake_type AS ENUM ('VALUE', 'UNIT');
+
+-- ========= TABLES =========
+CREATE TABLE bettor (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    type bettor_type NOT NULL DEFAULT 'FREE',
+    unit_value DECIMAL(8,2),
+    created_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+);
+
+CREATE TABLE bookmaker (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    bettor_id BIGINT NOT NULL,
+    CONSTRAINT fk_bookmaker_bettor FOREIGN KEY(bettor_id) REFERENCES bettor(id) ON DELETE CASCADE
+);
+
+CREATE TABLE tipster (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    bettor_id BIGINT NOT NULL,
+    CONSTRAINT fk_tipster_bettor FOREIGN KEY(bettor_id) REFERENCES bettor(id) ON DELETE CASCADE
+);
+
+CREATE TABLE sport (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    bettor_id BIGINT NOT NULL,
+    CONSTRAINT fk_sport_bettor FOREIGN KEY(bettor_id) REFERENCES bettor(id) ON DELETE CASCADE
+);
+
+CREATE TABLE competition (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    bettor_id BIGINT NOT NULL,
+    sport_id BIGINT NOT NULL,
+    CONSTRAINT fk_competition_bettor FOREIGN KEY(bettor_id) REFERENCES bettor(id) ON DELETE CASCADE,
+    CONSTRAINT fk_competition_sport FOREIGN KEY(sport_id) REFERENCES sport(id) ON DELETE CASCADE
+);
+
+CREATE TABLE transaction (
+    id BIGSERIAL PRIMARY KEY,
+    amount DECIMAL(8,2) NOT NULL,
+    type transaction_type NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+    bettor_id BIGINT NOT NULL,
+    bookmaker_id BIGINT NOT NULL,
+    CONSTRAINT fk_transaction_bettor FOREIGN KEY(bettor_id) REFERENCES bettor(id) ON DELETE CASCADE,
+    CONSTRAINT fk_transaction_bookmaker FOREIGN KEY(bookmaker_id) REFERENCES bookmaker(id) ON DELETE CASCADE
+);
+
+CREATE TABLE bet (
+    id BIGSERIAL PRIMARY KEY,
+    title VARCHAR(255),
+    selection VARCHAR(255) NOT NULL,
+    stake DECIMAL(8,2) NOT NULL,
+    stake_type stake_type NOT NULL DEFAULT 'VALUE',
+    odds DECIMAL(8,2) NOT NULL,
+    status bet_status NOT NULL DEFAULT 'PENDING',
+    event_date TIMESTAMP NOT NULL DEFAULT current_timestamp,
+    bettor_id BIGINT NOT NULL,
+    bookmaker_id BIGINT,
+    tipster_id BIGINT,
+    sport_id BIGINT,
+    competition_id BIGINT,
+    CONSTRAINT fk_bet_bettor FOREIGN KEY(bettor_id) REFERENCES bettor(id) ON DELETE CASCADE,
+    CONSTRAINT fk_bet_bookmaker FOREIGN KEY(bookmaker_id) REFERENCES bookmaker(id) ON DELETE SET NULL,
+    CONSTRAINT fk_bet_tipster FOREIGN KEY(tipster_id) REFERENCES tipster(id) ON DELETE SET NULL,
+    CONSTRAINT fk_bet_sport FOREIGN KEY(sport_id) REFERENCES sport(id) ON DELETE SET NULL,
+    CONSTRAINT fk_bet_competition FOREIGN KEY(competition_id) REFERENCES competition(id) ON DELETE SET NULL
+);
+
+-- ========= INDEXES =========
+CREATE INDEX idx_bookmaker_bettor_id ON bookmaker(bettor_id);
+CREATE INDEX idx_tipster_bettor_id ON tipster(bettor_id);
+CREATE INDEX idx_sport_bettor_id ON sport(bettor_id);
+CREATE INDEX idx_competition_bettor_id ON competition(bettor_id);
+CREATE INDEX idx_competition_sport_id ON competition(sport_id);
+CREATE INDEX idx_transaction_bettor_id ON transaction(bettor_id);
+CREATE INDEX idx_transaction_bookmaker_id ON transaction(bookmaker_id);
+CREATE INDEX idx_bet_bettor_id ON bet(bettor_id);
+CREATE INDEX idx_bet_bookmaker_id ON bet(bookmaker_id);
+CREATE INDEX idx_bet_tipster_id ON bet(tipster_id);
+CREATE INDEX idx_bet_sport_id ON bet(sport_id);
+CREATE INDEX idx_bet_competition_id ON bet(competition_id);


### PR DESCRIPTION
## Description

This pull request resolves the task of setting up an independent testing environment by configuring an H2 in-memory database.

This change decouples our test suite from the Dockerized PostgreSQL instance, leading to faster, more reliable, and portable tests. The new configuration automatically creates the schema from `schema.sql` and seeds it with `data.sql` whenever the test profile is active.

---

## Changes Made

-   **Dependency Management:** Added the `com.h2database:h2` dependency with a `test` scope in the `pom.xml`.
-   **Test Configuration:** Created a new `application-test.properties` file in `src/test/resources` to hold all H2-specific configurations.
-   **Database Initialization:**
    -   Added a `schema.sql` file to define the database schema for tests.
    -   Added a `data.sql` file to seed the database with initial data for testing.
-   **Test Activation:** Configured the main test class (`BettrackerApplicationTests`) with `@ActiveProfiles("test")` to ensure the new properties are loaded during the test phase.

Closes #11 