### PR TITLE
feat: Implement creation endpoints for core domain entities

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
@@ -1,0 +1,43 @@
+package io.github.joaomnz.bettracker.controller;
+
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import io.github.joaomnz.bettracker.security.BettorDetails;
+import io.github.joaomnz.bettracker.service.BookmakerService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequestMapping("/api/v1/bookmakers")
+@RestController
+public class BookmakerController {
+    private final BookmakerService bookmakerService;
+
+    public BookmakerController(BookmakerService bookmakerService) {
+        this.bookmakerService = bookmakerService;
+    }
+
+    @PostMapping
+    public ResponseEntity<BookmakerResponseDTO> create(@Valid @RequestBody BookmakerRequestDTO request, Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+        Bookmaker createdBookmaker = bookmakerService.create(request, currentBettor);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest().path("/{id}")
+                .buildAndExpand(createdBookmaker.getId())
+                .toUri();
+
+        BookmakerResponseDTO responseDTO = new BookmakerResponseDTO(createdBookmaker.getId(), createdBookmaker.getName());
+        return ResponseEntity.created(location).body(responseDTO);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
@@ -1,0 +1,48 @@
+package io.github.joaomnz.bettracker.controller;
+
+import io.github.joaomnz.bettracker.dto.competition.CompetitionRequestDTO;
+import io.github.joaomnz.bettracker.dto.competition.CompetitionResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Competition;
+import io.github.joaomnz.bettracker.model.Sport;
+import io.github.joaomnz.bettracker.security.BettorDetails;
+import io.github.joaomnz.bettracker.service.CompetitionService;
+import io.github.joaomnz.bettracker.service.SportService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequestMapping("/api/v1/sports/{sportId}/competitions")
+@RestController
+public class CompetitionController {
+    private final CompetitionService competitionService;
+    private final SportService sportService;
+
+    public CompetitionController(CompetitionService competitionService, SportService sportService) {
+        this.competitionService = competitionService;
+        this.sportService = sportService;
+    }
+
+    @PostMapping
+    public ResponseEntity<CompetitionResponseDTO> create(@PathVariable Long sportId,
+                                                         @Valid @RequestBody CompetitionRequestDTO request,
+                                                         Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+        Sport parentSport = sportService.findByIdAndBettor(sportId, currentBettor);
+        Competition createdCompetition = competitionService.create(request, parentSport);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(createdCompetition.getId())
+                .toUri();
+
+        CompetitionResponseDTO responseDTO = new CompetitionResponseDTO(createdCompetition.getId(), createdCompetition.getName());
+        return ResponseEntity.created(location).body(responseDTO);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
@@ -1,0 +1,44 @@
+package io.github.joaomnz.bettracker.controller;
+
+import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Sport;
+import io.github.joaomnz.bettracker.security.BettorDetails;
+import io.github.joaomnz.bettracker.service.SportService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequestMapping("/api/v1/sports")
+@RestController
+public class SportController {
+    private final SportService sportService;
+
+    public SportController(SportService sportService) {
+        this.sportService = sportService;
+    }
+
+    @PostMapping
+    public ResponseEntity<SportResponseDTO> create(@Valid @RequestBody SportRequestDTO request, Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+        Sport createdSport = sportService.create(request, currentBettor);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(createdSport.getId())
+                .toUri();
+
+        SportResponseDTO responseDTO = new SportResponseDTO(createdSport.getId(), createdSport.getName());
+        return ResponseEntity.created(location).body(responseDTO);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/TipsterController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/TipsterController.java
@@ -1,0 +1,42 @@
+package io.github.joaomnz.bettracker.controller;
+
+import io.github.joaomnz.bettracker.dto.tipster.TipsterRequestDTO;
+import io.github.joaomnz.bettracker.dto.tipster.TipsterResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Tipster;
+import io.github.joaomnz.bettracker.security.BettorDetails;
+import io.github.joaomnz.bettracker.service.TipsterService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequestMapping("/api/v1/tipsters")
+@RestController
+public class TipsterController {
+    private final TipsterService tipsterService;
+
+    public TipsterController(TipsterService tipsterService) {
+        this.tipsterService = tipsterService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TipsterResponseDTO> create(@Valid @RequestBody TipsterRequestDTO request, Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+        Tipster createdTipster = tipsterService.create(request, currentBettor);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(createdTipster.getId()).toUri();
+        TipsterResponseDTO responseDTO = new TipsterResponseDTO(createdTipster.getId(), createdTipster.getName());
+        return ResponseEntity.created(location).body(responseDTO);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
@@ -1,0 +1,52 @@
+package io.github.joaomnz.bettracker.controller;
+
+import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
+import io.github.joaomnz.bettracker.dto.transaction.TransactionResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import io.github.joaomnz.bettracker.model.Transaction;
+import io.github.joaomnz.bettracker.security.BettorDetails;
+import io.github.joaomnz.bettracker.service.BookmakerService;
+import io.github.joaomnz.bettracker.service.TransactionService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequestMapping("/api/v1/bookmakers/{bookmakerId}/transactions")
+@RestController
+public class TransactionController {
+    private final TransactionService transactionService;
+    private final BookmakerService bookmakerService;
+
+    public TransactionController(TransactionService transactionService, BookmakerService bookmakerService) {
+        this.transactionService = transactionService;
+        this.bookmakerService = bookmakerService;
+    }
+
+    @PostMapping
+    public ResponseEntity<TransactionResponseDTO> create(@PathVariable Long bookmakerId,
+                                                         @Valid @RequestBody TransactionRequestDTO request,
+                                                         Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+        Bookmaker parentBookmaker = bookmakerService.findByIdAndBettor(bookmakerId, currentBettor);
+        Transaction createdTransaction = transactionService.create(request, parentBookmaker);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(createdTransaction.getId())
+                .toUri();
+
+        TransactionResponseDTO responseDTO = new TransactionResponseDTO(
+                createdTransaction.getId(),
+                createdTransaction.getAmount(),
+                createdTransaction.getType(),
+                createdTransaction.getCreatedAt());
+        return ResponseEntity.created(location).body(responseDTO);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/advice/GlobalExceptionHandler.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/advice/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package io.github.joaomnz.bettracker.controller.advice;
 
 import io.github.joaomnz.bettracker.dto.shared.ErrorResponseDTO;
 import io.github.joaomnz.bettracker.exceptions.EmailAlreadyExistsException;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,5 +43,18 @@ public class GlobalExceptionHandler {
                 request.getRequestURI()
         );
         return ResponseEntity.badRequest().body(errorResponseDTO);
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ErrorResponseDTO> handleResourceNotFoundException(ResourceNotFoundException ex, HttpServletRequest request){
+        ErrorResponseDTO errorResponseDTO = new ErrorResponseDTO(
+                Instant.now(),
+                HttpStatus.NOT_FOUND.value(),
+                "Not Found",
+                ex.getMessage(),
+                null,
+                request.getRequestURI()
+        );
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponseDTO);
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/bookmaker/BookmakerRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/bookmaker/BookmakerRequestDTO.java
@@ -1,0 +1,8 @@
+package io.github.joaomnz.bettracker.dto.bookmaker;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record BookmakerRequestDTO(
+        @NotBlank
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/bookmaker/BookmakerRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/bookmaker/BookmakerRequestDTO.java
@@ -3,6 +3,6 @@ package io.github.joaomnz.bettracker.dto.bookmaker;
 import jakarta.validation.constraints.NotBlank;
 
 public record BookmakerRequestDTO(
-        @NotBlank
+        @NotBlank(message = "The name is required.")
         String name
 ) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/bookmaker/BookmakerResponseDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/bookmaker/BookmakerResponseDTO.java
@@ -1,0 +1,6 @@
+package io.github.joaomnz.bettracker.dto.bookmaker;
+
+public record BookmakerResponseDTO(
+        Long id,
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/competition/CompetitionRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/competition/CompetitionRequestDTO.java
@@ -3,6 +3,6 @@ package io.github.joaomnz.bettracker.dto.competition;
 import jakarta.validation.constraints.NotBlank;
 
 public record CompetitionRequestDTO(
-        @NotBlank
+        @NotBlank(message = "The name is required.")
         String name
 ) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/competition/CompetitionRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/competition/CompetitionRequestDTO.java
@@ -1,0 +1,8 @@
+package io.github.joaomnz.bettracker.dto.competition;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CompetitionRequestDTO(
+        @NotBlank
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/competition/CompetitionResponseDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/competition/CompetitionResponseDTO.java
@@ -1,0 +1,6 @@
+package io.github.joaomnz.bettracker.dto.competition;
+
+public record CompetitionResponseDTO(
+        Long id,
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/sport/SportRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/sport/SportRequestDTO.java
@@ -1,0 +1,8 @@
+package io.github.joaomnz.bettracker.dto.sport;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SportRequestDTO(
+        @NotBlank
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/sport/SportRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/sport/SportRequestDTO.java
@@ -3,6 +3,6 @@ package io.github.joaomnz.bettracker.dto.sport;
 import jakarta.validation.constraints.NotBlank;
 
 public record SportRequestDTO(
-        @NotBlank
+        @NotBlank(message = "The name is required.")
         String name
 ) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/sport/SportResponseDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/sport/SportResponseDTO.java
@@ -1,0 +1,6 @@
+package io.github.joaomnz.bettracker.dto.sport;
+
+public record SportResponseDTO(
+        Long id,
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/tipster/TipsterRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/tipster/TipsterRequestDTO.java
@@ -1,0 +1,8 @@
+package io.github.joaomnz.bettracker.dto.tipster;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TipsterRequestDTO(
+        @NotBlank(message = "The name is required.")
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/tipster/TipsterResponseDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/tipster/TipsterResponseDTO.java
@@ -1,0 +1,6 @@
+package io.github.joaomnz.bettracker.dto.tipster;
+
+public record TipsterResponseDTO(
+        Long id,
+        String name
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/transaction/TransactionRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/transaction/TransactionRequestDTO.java
@@ -1,0 +1,16 @@
+package io.github.joaomnz.bettracker.dto.transaction;
+
+import io.github.joaomnz.bettracker.model.enums.TransactionType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public record TransactionRequestDTO(
+        @NotNull(message = "Amount cannot be null.")
+        @Positive(message = "Amount must be positive.")
+        BigDecimal amount,
+
+        @NotNull(message = "Transaction type cannot be null.")
+        TransactionType type
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/transaction/TransactionResponseDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/transaction/TransactionResponseDTO.java
@@ -1,0 +1,13 @@
+package io.github.joaomnz.bettracker.dto.transaction;
+
+import io.github.joaomnz.bettracker.model.enums.TransactionType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record TransactionResponseDTO(
+        Long id,
+        BigDecimal amount,
+        TransactionType type,
+        LocalDateTime createdAt
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/exceptions/ResourceNotFoundException.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/exceptions/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.exceptions;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/BookmakerRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/BookmakerRepository.java
@@ -1,7 +1,11 @@
 package io.github.joaomnz.bettracker.repository;
 
+import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookmakerRepository extends JpaRepository<Bookmaker, Long> {
+    Optional<Bookmaker> findByIdAndBettor(Long bookmakerId, Bettor bettor);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/BookmakerRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/BookmakerRepository.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.repository;
+
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmakerRepository extends JpaRepository<Bookmaker, Long> {
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/CompetitionRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/CompetitionRepository.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.repository;
+
+import io.github.joaomnz.bettracker.model.Competition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompetitionRepository extends JpaRepository<Competition, Long> {
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/SportRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/SportRepository.java
@@ -1,7 +1,11 @@
 package io.github.joaomnz.bettracker.repository;
 
+import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Sport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SportRepository extends JpaRepository<Sport, Long> {
+    Optional<Sport> findByIdAndBettor(Long id, Bettor bettor);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/SportRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/SportRepository.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.repository;
+
+import io.github.joaomnz.bettracker.model.Sport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SportRepository extends JpaRepository<Sport, Long> {
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/TipsterRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/TipsterRepository.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.repository;
+
+import io.github.joaomnz.bettracker.model.Tipster;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TipsterRepository extends JpaRepository<Tipster, Long> {
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/TransactionRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/TransactionRepository.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.repository;
+
+import io.github.joaomnz.bettracker.model.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -31,6 +31,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/me").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/tipsters").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sports").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -30,6 +30,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/me").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/tipsters").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sports").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -33,6 +33,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/sports").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sports/{sportId}/competitions").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers/{bookmakerId}/transactions").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -32,6 +32,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/tipsters").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sports").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/sports/{sportId}/competitions").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -29,6 +29,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/register").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/users/me").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/tipsters").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
@@ -1,6 +1,7 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.repository.BookmakerRepository;
@@ -19,5 +20,10 @@ public class BookmakerService {
         newBookmaker.setName(request.name());
         newBookmaker.setBettor(currentBettor);
         return bookmakerRepository.save(newBookmaker);
+    }
+
+    public Bookmaker findByIdAndBettor(Long bookmakerId, Bettor currentBettor){
+        return bookmakerRepository.findByIdAndBettor(bookmakerId, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Bookmaker not found with id " + bookmakerId + " for this bettor."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
@@ -1,0 +1,23 @@
+package io.github.joaomnz.bettracker.service;
+
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import io.github.joaomnz.bettracker.repository.BookmakerRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookmakerService {
+    private final BookmakerRepository bookmakerRepository;
+
+    public BookmakerService(BookmakerRepository bookmakerRepository) {
+        this.bookmakerRepository = bookmakerRepository;
+    }
+
+    public Bookmaker create(BookmakerRequestDTO request, Bettor currentBettor){
+        Bookmaker newBookmaker = new Bookmaker();
+        newBookmaker.setName(request.name());
+        newBookmaker.setBettor(currentBettor);
+        return bookmakerRepository.save(newBookmaker);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
@@ -1,0 +1,24 @@
+package io.github.joaomnz.bettracker.service;
+
+import io.github.joaomnz.bettracker.dto.competition.CompetitionRequestDTO;
+import io.github.joaomnz.bettracker.model.Competition;
+import io.github.joaomnz.bettracker.model.Sport;
+import io.github.joaomnz.bettracker.repository.CompetitionRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CompetitionService {
+    private final CompetitionRepository competitionRepository;
+
+    public CompetitionService(CompetitionRepository competitionRepository) {
+        this.competitionRepository = competitionRepository;
+    }
+
+    public Competition create(CompetitionRequestDTO request, Sport parentSport){
+        Competition newCompetition = new Competition();
+        newCompetition.setName(request.name());
+        newCompetition.setSport(parentSport);
+        newCompetition.setBettor(parentSport.getBettor());
+        return competitionRepository.save(newCompetition);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
@@ -1,6 +1,7 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Sport;
 import io.github.joaomnz.bettracker.repository.SportRepository;
@@ -19,5 +20,10 @@ public class SportService {
         newSport.setName(request.name());
         newSport.setBettor(currentBettor);
         return sportRepository.save(newSport);
+    }
+
+    public Sport findByIdAndBettor(Long sportId, Bettor currentBettor){
+        return sportRepository.findByIdAndBettor(sportId, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Sport not found with id " + sportId + " for this bettor."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
@@ -1,0 +1,23 @@
+package io.github.joaomnz.bettracker.service;
+
+import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Sport;
+import io.github.joaomnz.bettracker.repository.SportRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SportService {
+    private final SportRepository sportRepository;
+
+    public SportService(SportRepository sportRepository) {
+        this.sportRepository = sportRepository;
+    }
+
+    public Sport create(SportRequestDTO request, Bettor currentBettor){
+        Sport newSport = new Sport();
+        newSport.setName(request.name());
+        newSport.setBettor(currentBettor);
+        return sportRepository.save(newSport);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TipsterService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TipsterService.java
@@ -1,0 +1,23 @@
+package io.github.joaomnz.bettracker.service;
+
+import io.github.joaomnz.bettracker.dto.tipster.TipsterRequestDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Tipster;
+import io.github.joaomnz.bettracker.repository.TipsterRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TipsterService {
+    private final TipsterRepository tipsterRepository;
+
+    public TipsterService(TipsterRepository tipsterRepository) {
+        this.tipsterRepository = tipsterRepository;
+    }
+
+    public Tipster create(TipsterRequestDTO request, Bettor currentBettor){
+        Tipster newTipster = new Tipster();
+        newTipster.setName(request.name());
+        newTipster.setBettor(currentBettor);
+        return tipsterRepository.save(newTipster);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
@@ -1,0 +1,25 @@
+package io.github.joaomnz.bettracker.service;
+
+import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import io.github.joaomnz.bettracker.model.Transaction;
+import io.github.joaomnz.bettracker.repository.TransactionRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransactionService {
+    private final TransactionRepository transactionRepository;
+
+    public TransactionService(TransactionRepository transactionRepository) {
+        this.transactionRepository = transactionRepository;
+    }
+
+    public Transaction create(TransactionRequestDTO request, Bookmaker parentBookmaker){
+        Transaction newTransaction = new Transaction();
+        newTransaction.setAmount(request.amount());
+        newTransaction.setType(request.type());
+        newTransaction.setBookmaker(parentBookmaker);
+        newTransaction.setBettor(parentBookmaker.getBettor());
+        return  transactionRepository.save(newTransaction);
+    }
+}

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/BookmakerControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/BookmakerControllerIT.java
@@ -1,0 +1,59 @@
+package io.github.joaomnz.bettracker.integration;
+
+import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
+import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class BookmakerControllerIT {
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private final String BOOKMAKER_API_URI = "/api/v1/bookmakers";
+
+    @Test
+    @DisplayName("Should create a bookmaker when authenticated and data is valid")
+    void shouldCreateBookmakerWhenAuthenticated() {
+        BookmakerRequestDTO newBookmaker = new BookmakerRequestDTO("Bet365");
+        String token = registerBettorAndGetToken();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<BookmakerRequestDTO> httpEntity = new HttpEntity<>(newBookmaker, headers);
+
+        ResponseEntity<BookmakerResponseDTO> response =
+                testRestTemplate.exchange(BOOKMAKER_API_URI, HttpMethod.POST, httpEntity, BookmakerResponseDTO.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isNotNull();
+        assertThat(response.getBody().name()).isEqualTo("Bet365");
+    }
+
+    @Test
+    @DisplayName("Should return 403 Forbidden when trying to create a bookmaker without authentication")
+    void shouldReturnForbiddenWhenNotAuthenticated() {
+        BookmakerRequestDTO newBookmaker = new BookmakerRequestDTO("Bet365");
+        HttpEntity<BookmakerRequestDTO> httpEntity = new HttpEntity<>(newBookmaker);
+        ResponseEntity<Void> response = testRestTemplate.exchange(BOOKMAKER_API_URI, HttpMethod.POST, httpEntity, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    private String registerBettorAndGetToken() {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("João", "joao.menezes21@Outlook.com", "Password123!");
+        ResponseEntity<LoginResponseDTO> response =
+                testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().token();
+    }
+}

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/CompetitionControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/CompetitionControllerIT.java
@@ -1,0 +1,141 @@
+package io.github.joaomnz.bettracker.integration;
+
+import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
+import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.competition.CompetitionRequestDTO;
+import io.github.joaomnz.bettracker.dto.competition.CompetitionResponseDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CompetitionControllerIT {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private final String SPORTS_API_URI = "/api/v1/sports";
+
+    @Test
+    @DisplayName("Should create a competition when authenticated and sport belongs to the user")
+    void shouldCreateCompetitionWhenAuthenticatedAndSportIsValid() {
+        AuthContext authContext = registerUserAndCreateSport("user1@email.com", "Football");
+        String competitionApiUri = SPORTS_API_URI + "/" + authContext.sportId() + "/competitions";
+
+        CompetitionRequestDTO newCompetitionRequest = new CompetitionRequestDTO("Premier League");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(authContext.token());
+        HttpEntity<CompetitionRequestDTO> requestEntity = new HttpEntity<>(newCompetitionRequest, headers);
+
+        ResponseEntity<CompetitionResponseDTO> response = testRestTemplate.exchange(
+                competitionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                CompetitionResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isNotNull();
+        assertThat(response.getBody().name()).isEqualTo("Premier League");
+    }
+
+    @Test
+    @DisplayName("Should return 403 Forbidden when trying to create a competition without authentication")
+    void shouldReturnForbiddenWhenNotAuthenticated() {
+        AuthContext authContext = registerUserAndCreateSport("user2@email.com", "Basketball");
+        String competitionApiUri = SPORTS_API_URI + "/" + authContext.sportId() + "/competitions";
+
+        CompetitionRequestDTO newCompetitionRequest = new CompetitionRequestDTO("NBA");
+        HttpEntity<CompetitionRequestDTO> requestEntity = new HttpEntity<>(newCompetitionRequest);
+
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                competitionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to create a competition for a non-existent sport")
+    void shouldReturnNotFoundWhenSportDoesNotExist() {
+        String token = registerUserAndGetToken("user3@email.com");
+        long nonExistentSportId = 999L;
+        String competitionApiUri = SPORTS_API_URI + "/" + nonExistentSportId + "/competitions";
+
+        CompetitionRequestDTO newCompetitionRequest = new CompetitionRequestDTO("NFL");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<CompetitionRequestDTO> requestEntity = new HttpEntity<>(newCompetitionRequest, headers);
+
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                competitionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to create a competition for a sport that belongs to another user")
+    void shouldReturnNotFoundWhenSportBelongsToAnotherUser() {
+        AuthContext userA = registerUserAndCreateSport("userA@email.com", "Formula 1");
+
+        String tokenUserB = registerUserAndGetToken("userB@email.com");
+
+        String competitionApiUri = SPORTS_API_URI + "/" + userA.sportId() + "/competitions";
+        CompetitionRequestDTO newCompetitionRequest = new CompetitionRequestDTO("Monaco GP");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenUserB);
+        HttpEntity<CompetitionRequestDTO> requestEntity = new HttpEntity<>(newCompetitionRequest, headers);
+
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                competitionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    private String registerUserAndGetToken(String email) {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("Test User", email, "Password123!");
+        ResponseEntity<LoginResponseDTO> response =
+                testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().token();
+    }
+
+    private AuthContext registerUserAndCreateSport(String email, String sportName) {
+        String token = registerUserAndGetToken(email);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        SportRequestDTO newSportRequest = new SportRequestDTO(sportName);
+        HttpEntity<SportRequestDTO> requestEntity = new HttpEntity<>(newSportRequest, headers);
+
+        ResponseEntity<SportResponseDTO> sportResponse = testRestTemplate.exchange(
+                SPORTS_API_URI, HttpMethod.POST, requestEntity, SportResponseDTO.class);
+
+        assertThat(sportResponse.getBody()).isNotNull();
+        Long sportId = sportResponse.getBody().id();
+        return new AuthContext(token, sportId);
+    }
+
+    private record AuthContext(String token, Long sportId) {}
+}

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/SportControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/SportControllerIT.java
@@ -1,0 +1,59 @@
+package io.github.joaomnz.bettracker.integration;
+
+import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
+import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class SportControllerIT {
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private final String SPORT_API_URI = "/api/v1/sports";
+
+    @Test
+    @DisplayName("Should create a sport when authenticated and data is valid")
+    void shouldCreateSportWhenAuthenticated() {
+        SportRequestDTO newSport = new SportRequestDTO("Football");
+        String token = registerBettorAndGetToken();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<SportRequestDTO> httpEntity = new HttpEntity<>(newSport, headers);
+
+        ResponseEntity<SportResponseDTO> response =
+                testRestTemplate.exchange(SPORT_API_URI, HttpMethod.POST, httpEntity, SportResponseDTO.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isNotNull();
+        assertThat(response.getBody().name()).isEqualTo("Football");
+    }
+
+    @Test
+    @DisplayName("Should return 403 Forbidden when trying to create a sport without authentication")
+    void shouldReturnForbiddenWhenNotAuthenticated() {
+        SportRequestDTO newSport = new SportRequestDTO("Football");
+        HttpEntity<SportRequestDTO> httpEntity = new HttpEntity<>(newSport);
+        ResponseEntity<Void> response = testRestTemplate.exchange(SPORT_API_URI, HttpMethod.POST, httpEntity, Void.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    private String registerBettorAndGetToken() {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("João", "joao.menezes21@Outlook.com", "Password123!");
+        ResponseEntity<LoginResponseDTO> response =
+                testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().token();
+    }
+}

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/TipsterControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/TipsterControllerIT.java
@@ -1,0 +1,68 @@
+package io.github.joaomnz.bettracker.integration;
+
+import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
+import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.tipster.TipsterRequestDTO;
+import io.github.joaomnz.bettracker.dto.tipster.TipsterResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class TipsterControllerIT {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private final String TIPSTER_API_URI = "/api/v1/tipsters";
+
+    @Test
+    @DisplayName("Should create a tipster when authenticated and data is valid")
+    void shouldCreateTipsterWhenAuthenticated() {
+        String token = registerBettorAndGetToken();
+        TipsterRequestDTO newTipsterRequest = new TipsterRequestDTO("Pei!");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<TipsterRequestDTO> requestEntity = new HttpEntity<>(newTipsterRequest, headers);
+        ResponseEntity<TipsterResponseDTO> response = testRestTemplate.exchange(
+                TIPSTER_API_URI,
+                HttpMethod.POST,
+                requestEntity,
+                TipsterResponseDTO.class
+        );
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isNotNull();
+        assertThat(response.getBody().name()).isEqualTo("Pei!");
+    }
+
+    @Test
+    @DisplayName("Should return 403 Forbidden when trying to create a tipster without authentication")
+    void shouldReturnForbiddenWhenNotAuthenticated() {
+        TipsterRequestDTO newTipsterRequest = new TipsterRequestDTO("Pei!");
+        HttpEntity<TipsterRequestDTO> requestEntity = new HttpEntity<>(newTipsterRequest);
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                TIPSTER_API_URI,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    private String registerBettorAndGetToken() {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("João", "joao.menezes21@Outlook.com", "Password123!");
+        ResponseEntity<LoginResponseDTO> response =
+                testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().token();
+    }
+}

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/TransactionControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/TransactionControllerIT.java
@@ -1,0 +1,122 @@
+package io.github.joaomnz.bettracker.integration;
+
+import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
+import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
+import io.github.joaomnz.bettracker.dto.transaction.TransactionResponseDTO;
+import io.github.joaomnz.bettracker.model.enums.TransactionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class TransactionControllerIT {
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private final String BOOKMAKERS_API_URI = "/api/v1/bookmakers";
+
+    @Test
+    @DisplayName("Should create a transaction when authenticated and bookmaker belongs to the user")
+    void shouldCreateTransactionWhenAuthenticatedAndBookmakerIsValid() {
+        AuthContext authContext = registerUserAndCreateBookmaker("user1@email.com", "Bet365");
+        String transactionApiUri = BOOKMAKERS_API_URI + "/" + authContext.bookmakerId() + "/transactions";
+
+        TransactionRequestDTO newTransactionRequest = new TransactionRequestDTO(new BigDecimal("100.00"), TransactionType.DEPOSIT);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(authContext.token());
+        HttpEntity<TransactionRequestDTO> requestEntity = new HttpEntity<>(newTransactionRequest, headers);
+
+        ResponseEntity<TransactionResponseDTO> response = testRestTemplate.exchange(
+                transactionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                TransactionResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isNotNull();
+        assertThat(response.getBody().amount()).isEqualTo(new BigDecimal("100.00"));
+        assertThat(response.getBody().type()).isEqualTo(TransactionType.DEPOSIT);
+    }
+
+    @Test
+    @DisplayName("Should return 403 Forbidden when trying to create a transaction without authentication")
+    void shouldReturnForbiddenWhenNotAuthenticated() {
+        AuthContext authContext = registerUserAndCreateBookmaker("user2@email.com", "Betano");
+        String transactionApiUri = BOOKMAKERS_API_URI + "/" + authContext.bookmakerId() + "/transactions";
+
+        TransactionRequestDTO newTransactionRequest = new TransactionRequestDTO(new BigDecimal("50.00"), TransactionType.DEPOSIT);
+        HttpEntity<TransactionRequestDTO> requestEntity = new HttpEntity<>(newTransactionRequest);
+
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                transactionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to create a transaction for a bookmaker that belongs to another user")
+    void shouldReturnNotFoundWhenBookmakerBelongsToAnotherUser() {
+        AuthContext userA = registerUserAndCreateBookmaker("userA@email.com", "Pinnacle");
+
+        String tokenUserB = registerUserAndGetToken("userB@email.com");
+
+        String transactionApiUri = BOOKMAKERS_API_URI + "/" + userA.bookmakerId() + "/transactions";
+        TransactionRequestDTO newTransactionRequest = new TransactionRequestDTO(new BigDecimal("200.00"), TransactionType.DEPOSIT);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenUserB);
+        HttpEntity<TransactionRequestDTO> requestEntity = new HttpEntity<>(newTransactionRequest, headers);
+
+        ResponseEntity<String> response = testRestTemplate.exchange(
+                transactionApiUri,
+                HttpMethod.POST,
+                requestEntity,
+                String.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    private String registerUserAndGetToken(String email) {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("Test User", email, "Password123!");
+        ResponseEntity<LoginResponseDTO> response =
+                testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().token();
+    }
+
+    private AuthContext registerUserAndCreateBookmaker(String email, String bookmakerName) {
+        String token = registerUserAndGetToken(email);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        BookmakerRequestDTO newBookmakerRequest = new BookmakerRequestDTO(bookmakerName);
+        HttpEntity<BookmakerRequestDTO> requestEntity = new HttpEntity<>(newBookmakerRequest, headers);
+
+        ResponseEntity<BookmakerResponseDTO> bookmakerResponse = testRestTemplate.exchange(
+                BOOKMAKERS_API_URI, HttpMethod.POST, requestEntity, BookmakerResponseDTO.class);
+        assertThat(bookmakerResponse.getBody()).isNotNull();
+        Long bookmakerId = bookmakerResponse.getBody().id();
+        return new AuthContext(token, bookmakerId);
+    }
+
+    private record AuthContext(String token, Long bookmakerId) {}
+}


### PR DESCRIPTION
### Problem Description

With the authentication system in place, this pull request builds the core business logic of the application. It introduces the necessary API endpoints, services, and DTOs to allow an authenticated user (`Bettor`) to create their primary resources: `Bookmaker`, `Sport`, `Tipster`, `Competition`, and `Transaction`.

A key focus of this implementation is to enforce data ownership by ensuring every new resource is correctly associated with the logged-in user. For nested resources like `Competition` and `Transaction`, service-layer validation has been added to prevent users from creating resources under parent entities they do not own.

### Changes Made

-   [x] **DTOs:** Created `Request` and `Response` DTOs for `Bookmaker`, `Sport`, `Tipster`, `Competition`, and `Transaction`.
-   [x] **Simple Resources:** Implemented the full Service-Controller stack for creating `Bookmaker`, `Sport`, and `Tipster` at their respective endpoints (`/api/v1/bookmakers`, etc.).
-   [x] **Nested Resource (`Competition`):** Implemented the creation flow for `Competition` under a `Sport` via the `POST /api/v1/sports/{sportId}/competitions` endpoint.
-   [x] **Nested Resource (`Transaction`):** Implemented the creation flow for `Transaction` under a `Bookmaker` via the `POST /api/v1/bookmakers/{bookmakerId}/transactions` endpoint.
-   [x] **Security:**
    -   Updated `SecurityConfiguration` to protect all new endpoints, requiring authentication.
    -   Added service-layer logic to validate that users can only create nested resources under parent entities that they own.
-   [x] **Testing:** Added comprehensive integration tests (`...IT.java`) for each new controller, covering:
    -   Successful creation with a valid token (201 Created).
    -   Access denial without a token (403 Forbidden).
    -   Access denial when trying to create a resource under a parent entity owned by another user (404 Not Found).

Closes #17