### PR TITLE
feat: Implement endpoint to create a new Bet

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/BetController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/BetController.java
@@ -1,0 +1,79 @@
+package io.github.joaomnz.bettracker.controller;
+
+import io.github.joaomnz.bettracker.dto.bet.CreateBetRequestDTO;
+import io.github.joaomnz.bettracker.dto.bet.CreateBetResponseDTO;
+import io.github.joaomnz.bettracker.model.*;
+import io.github.joaomnz.bettracker.security.BettorDetails;
+import io.github.joaomnz.bettracker.service.*;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RequestMapping("/api/v1/bets")
+@RestController
+public class BetController {
+    private final BetService betService;
+    private final BookmakerService bookmakerService;
+    private final TipsterService tipsterService;
+    private final SportService sportService;
+    private final CompetitionService competitionService;
+
+    public BetController(BetService betService,
+                         BookmakerService bookmakerService,
+                         TipsterService tipsterService,
+                         SportService sportService,
+                         CompetitionService competitionService) {
+        this.betService = betService;
+        this.bookmakerService = bookmakerService;
+        this.tipsterService = tipsterService;
+        this.sportService = sportService;
+        this.competitionService = competitionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateBetResponseDTO> create(@Valid @RequestBody CreateBetRequestDTO request, Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+
+        Bookmaker associatedBookmaker = null;
+        Tipster associatedTipster = null;
+        Sport associatedSport = null;
+        Competition associatedCompetition = null;
+
+        if(request.BookmakerId() != null) associatedBookmaker = bookmakerService.findByIdAndBettor(request.BookmakerId(), currentBettor);
+        if(request.tipsterId() != null) associatedTipster = tipsterService.findByIdAndBettor(request.tipsterId(), currentBettor);
+        if(request.sportId() != null) associatedSport = sportService.findByIdAndBettor(request.sportId(), currentBettor);
+        if(request.competitionId() != null && associatedSport != null) associatedCompetition = competitionService.findByIdAndSport(request.competitionId(), associatedSport);
+
+        Bet createdBet = betService.create(request, associatedBookmaker, associatedTipster, associatedSport, associatedCompetition, currentBettor);
+
+        CreateBetResponseDTO responseDTO = new CreateBetResponseDTO(
+                createdBet.getId(),
+                createdBet.getTitle(),
+                createdBet.getSelection(),
+                createdBet.getStake(),
+                createdBet.getOdds(),
+                createdBet.getStatus(),
+                createdBet.getEventDate(),
+                associatedBookmaker != null ? associatedBookmaker.getName() : null,
+                associatedTipster != null ? associatedTipster.getName() : null,
+                associatedSport != null ? associatedSport.getName() : null,
+                associatedCompetition != null ? associatedCompetition.getName() : null
+        );
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(createdBet.getId())
+                .toUri();
+
+        return ResponseEntity.created(location).body(responseDTO);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/bet/CreateBetRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/bet/CreateBetRequestDTO.java
@@ -1,0 +1,36 @@
+package io.github.joaomnz.bettracker.dto.bet;
+
+import io.github.joaomnz.bettracker.model.enums.BetStatus;
+import io.github.joaomnz.bettracker.model.enums.StakeType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CreateBetRequestDTO(
+        String title,
+
+        @NotBlank(message = "The selection is required.")
+        String selection,
+
+        @Positive(message = "Stake must be positive.")
+        @NotNull(message = "Stake cannot be null.")
+        BigDecimal stake,
+
+        StakeType stakeType,
+
+        @Positive(message = "Odds must be positive.")
+        @NotNull(message = "Odds cannot be null.")
+        BigDecimal odds,
+
+        BetStatus status,
+
+        LocalDateTime eventDate,
+
+        Long BookmakerId,
+        Long tipsterId,
+        Long sportId,
+        Long competitionId
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/bet/CreateBetResponseDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/bet/CreateBetResponseDTO.java
@@ -1,0 +1,20 @@
+package io.github.joaomnz.bettracker.dto.bet;
+
+import io.github.joaomnz.bettracker.model.enums.BetStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CreateBetResponseDTO(
+        Long id,
+        String title,
+        String selection,
+        BigDecimal stake,
+        BigDecimal odds,
+        BetStatus status,
+        LocalDateTime eventDate,
+        String bookmaker,
+        String tipster,
+        String sport,
+        String competition
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/model/Bet.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/model/Bet.java
@@ -3,10 +3,7 @@ package io.github.joaomnz.bettracker.model;
 import io.github.joaomnz.bettracker.model.enums.BetStatus;
 import io.github.joaomnz.bettracker.model.enums.StakeType;
 import jakarta.persistence.*;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -17,6 +14,7 @@ import java.time.LocalDateTime;
 @Setter
 @EqualsAndHashCode(of = "id")
 @ToString
+@Builder
 public class Bet {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/BetRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/BetRepository.java
@@ -1,0 +1,7 @@
+package io.github.joaomnz.bettracker.repository;
+
+import io.github.joaomnz.bettracker.model.Bet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BetRepository extends JpaRepository<Bet, Long> {
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/CompetitionRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/CompetitionRepository.java
@@ -1,7 +1,11 @@
 package io.github.joaomnz.bettracker.repository;
 
 import io.github.joaomnz.bettracker.model.Competition;
+import io.github.joaomnz.bettracker.model.Sport;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CompetitionRepository extends JpaRepository<Competition, Long> {
+    Optional<Competition> findByIdAndSport(Long id, Sport sport);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/TipsterRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/TipsterRepository.java
@@ -1,7 +1,11 @@
 package io.github.joaomnz.bettracker.repository;
 
+import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Tipster;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TipsterRepository extends JpaRepository<Tipster, Long> {
+    Optional<Tipster> findByIdAndBettor(Long id, Bettor bettor);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -34,6 +34,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/sports/{sportId}/competitions").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers/{bookmakerId}/transactions").authenticated()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/bets").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BetService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BetService.java
@@ -1,0 +1,46 @@
+package io.github.joaomnz.bettracker.service;
+
+import io.github.joaomnz.bettracker.dto.bet.CreateBetRequestDTO;
+import io.github.joaomnz.bettracker.model.*;
+import io.github.joaomnz.bettracker.model.enums.BetStatus;
+import io.github.joaomnz.bettracker.model.enums.StakeType;
+import io.github.joaomnz.bettracker.repository.BetRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class BetService {
+    private final BetRepository betRepository;
+
+    public BetService(BetRepository betRepository) {
+        this.betRepository = betRepository;
+    }
+
+    public Bet create(CreateBetRequestDTO request,
+                      Bookmaker associatedBookmaker,
+                      Tipster associatedTipster,
+                      Sport associatedSport,
+                      Competition associatedCompetition,
+                      Bettor currentBettor){
+        StakeType stakeType = request.stakeType() != null ? request.stakeType() : StakeType.VALUE;
+        BetStatus status = request.status() != null ? request.status() : BetStatus.PENDING;
+        LocalDateTime eventDate = request.eventDate() != null ? request.eventDate() : LocalDateTime.now();
+
+        Bet newBet = new Bet();
+        newBet.setTitle(request.title());
+        newBet.setSelection(request.selection());
+        newBet.setStake(request.stake());
+        newBet.setStakeType(stakeType);
+        newBet.setOdds(request.odds());
+        newBet.setStatus(status);
+        newBet.setEventDate(eventDate);
+        newBet.setBettor(currentBettor);
+        newBet.setBookmaker(associatedBookmaker);
+        newBet.setTipster(associatedTipster);
+        newBet.setSport(associatedSport);
+        newBet.setCompetition(associatedCompetition);
+
+        return betRepository.save(newBet);
+    }
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
@@ -1,6 +1,7 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.competition.CompetitionRequestDTO;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Competition;
 import io.github.joaomnz.bettracker.model.Sport;
 import io.github.joaomnz.bettracker.repository.CompetitionRepository;
@@ -20,5 +21,10 @@ public class CompetitionService {
         newCompetition.setSport(parentSport);
         newCompetition.setBettor(parentSport.getBettor());
         return competitionRepository.save(newCompetition);
+    }
+
+    public Competition findByIdAndSport(Long competitionId, Sport parentSport){
+        return competitionRepository.findByIdAndSport(competitionId, parentSport)
+                .orElseThrow(() -> new ResourceNotFoundException("Competition not found with id " + competitionId + " for this sport."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TipsterService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TipsterService.java
@@ -1,6 +1,7 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.tipster.TipsterRequestDTO;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Tipster;
 import io.github.joaomnz.bettracker.repository.TipsterRepository;
@@ -19,5 +20,10 @@ public class TipsterService {
         newTipster.setName(request.name());
         newTipster.setBettor(currentBettor);
         return tipsterRepository.save(newTipster);
+    }
+
+    public Tipster findByIdAndBettor(Long tipsterId, Bettor curentBettor){
+        return tipsterRepository.findByIdAndBettor(tipsterId, curentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Tipster not found with id " + tipsterId + " for this bettor."));
     }
 }

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/BetControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/BetControllerIT.java
@@ -1,0 +1,167 @@
+package io.github.joaomnz.bettracker.integration;
+
+import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
+import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.bet.CreateBetRequestDTO;
+import io.github.joaomnz.bettracker.dto.bet.CreateBetResponseDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.dto.competition.CompetitionRequestDTO;
+import io.github.joaomnz.bettracker.dto.competition.CompetitionResponseDTO;
+import io.github.joaomnz.bettracker.dto.shared.ErrorResponseDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
+import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import io.github.joaomnz.bettracker.dto.tipster.TipsterRequestDTO;
+import io.github.joaomnz.bettracker.dto.tipster.TipsterResponseDTO;
+import io.github.joaomnz.bettracker.model.enums.StakeType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.*;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class BetControllerIT {
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    private final String BOOKMAKERS_API_URI = "/api/v1/bookmakers";
+    private final String TIPSTERS_API_URI = "/api/v1/tipsters";
+    private final String SPORTS_API_URI = "/api/v1/sports";
+    private final String BETS_API_URI = "/api/v1/bets";
+
+    @Test
+    @DisplayName("Should create a bet when authenticated and bookmaker belongs to the user")
+    void shouldCreateBetWhenAuthenticatedAndBookmakerIsValid() {
+        String token = registerUserAndGetToken("joao.menezes21@Outlook.com");
+        Long bookmakerId = createBookmaker(token, "Bet365");
+        Long tipsterId = createTipster(token, "Pei!");
+        Long sportId = createSport(token, "Football");
+        Long competitionId = createCompetition(token, sportId, "Premier League");
+
+        CreateBetRequestDTO request = new CreateBetRequestDTO(
+                "Vasco x Botafogo",
+                "ML Vasco",
+                BigDecimal.TWO,
+                StakeType.UNIT,
+                BigDecimal.valueOf(2.5),
+                null,
+                null,
+                bookmakerId,
+                tipsterId,
+                sportId,
+                competitionId
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<CreateBetRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<CreateBetResponseDTO> response = testRestTemplate
+                .exchange(BETS_API_URI, HttpMethod.POST, httpEntity, CreateBetResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().selection()).isEqualTo("ML Vasco");
+        assertThat(response.getBody().bookmaker()).isEqualTo("Bet365");
+        assertThat(response.getBody().tipster()).isEqualTo("Pei!");
+        assertThat(response.getBody().sport()).isEqualTo("Football");
+        assertThat(response.getBody().competition()).isEqualTo("Premier League");
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to create a bet with a bookmaker from another user")
+    void shouldReturnNotFoundWhenBookmakerBelongsToAnotherUser() {
+        String tokenUserA = registerUserAndGetToken("userA@email.com");
+        Long bookmakerIdUserA = createBookmaker(tokenUserA, "Bookmaker of A");
+
+        String tokenUserB = registerUserAndGetToken("userB@email.com");
+
+        CreateBetRequestDTO request = new CreateBetRequestDTO(
+                "Invalid Bet", "Any selection", BigDecimal.TEN, StakeType.VALUE, BigDecimal.TEN,
+                null, null, bookmakerIdUserA, null, null, null
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenUserB);
+        HttpEntity<CreateBetRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<ErrorResponseDTO> response = testRestTemplate
+                .exchange(BETS_API_URI, HttpMethod.POST, httpEntity, ErrorResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().message()).isEqualTo("Bookmaker not found with id " + bookmakerIdUserA + " for this bettor.");
+    }
+
+    private String registerUserAndGetToken(String email) {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("Test User", email, "Password123!");
+        ResponseEntity<LoginResponseDTO> response =
+                testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().token();
+    }
+
+    private Long createBookmaker(String token, String bookmakerName){
+        BookmakerRequestDTO request = new BookmakerRequestDTO(bookmakerName);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<BookmakerRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<BookmakerResponseDTO> response = testRestTemplate
+                .exchange(BOOKMAKERS_API_URI, HttpMethod.POST, httpEntity, BookmakerResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().id();
+    }
+
+    private Long createTipster(String token, String tipsterName){
+        TipsterRequestDTO request = new TipsterRequestDTO(tipsterName);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<TipsterRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<TipsterResponseDTO> response = testRestTemplate
+                .exchange(TIPSTERS_API_URI, HttpMethod.POST, httpEntity, TipsterResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().id();
+    }
+
+    private Long createSport(String token, String sportName){
+        SportRequestDTO request = new SportRequestDTO(sportName);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<SportRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<SportResponseDTO> response = testRestTemplate
+                .exchange(SPORTS_API_URI, HttpMethod.POST, httpEntity, SportResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().id();
+    }
+
+    private Long createCompetition(String token, Long sportId, String competitionName){
+        CompetitionRequestDTO request = new CompetitionRequestDTO(competitionName);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<CompetitionRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<CompetitionResponseDTO> response = testRestTemplate
+                .exchange(SPORTS_API_URI + "/" + sportId + "/competitions", HttpMethod.POST, httpEntity, CompetitionResponseDTO.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().id();
+    }
+}


### PR DESCRIPTION
### Problem Description

This pull request implements the core feature of the application: allowing an authenticated user to create a new `Bet`. This is a complex operation that involves validating and associating multiple user-owned resources like `Bookmaker`, `Sport`, `Competition`, and `Tipster`.

The implementation follows a "Controller as Orchestrator" pattern, where the controller is responsible for validating the user's ownership of all associated entities before calling the service to create the bet. This ensures data integrity and security, preventing a user from creating a bet linked to resources they do not own.

### Changes Made

-   [x] **DTOs:** Created a `CreateBetRequestDTO` for handling input with optional associations and a `BetResponseDTO` that returns a structured, nested view of the created bet and its related entities.
-   [x] **Service (`BetService`):** Implemented the `create` method, which handles business logic for default values (e.g., `status`, `eventDate`) and persists the new `Bet` entity.
-   [x] **Controller (`BetController`):**
    -   Created the `POST /api/v1/bets` endpoint.
    -   Implemented the orchestration logic to conditionally fetch and validate associated resources (`Bookmaker`, `Sport`, etc.) based on the request payload.
-   [x] **Security:** Updated `SecurityConfiguration` to protect the new `/api/v1/bets` endpoint. The service-layer validation of associated entities provides a second layer of defense.
-   [x] **Testing:** Added a robust integration test suite (`BetControllerIT.java`) covering:
    -   A successful creation scenario with all associations.
    -   A security scenario to ensure a user cannot create a bet using a `Bookmaker` owned by another user, correctly returning a `404 Not Found`.

Closes #19 