### PR TITLE
Implement Bet delete endpoint and tests.

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/BetController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/BetController.java
@@ -6,12 +6,10 @@ import io.github.joaomnz.bettracker.model.*;
 import io.github.joaomnz.bettracker.security.BettorDetails;
 import io.github.joaomnz.bettracker.service.*;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -75,5 +73,15 @@ public class BetController {
                 .toUri();
 
         return ResponseEntity.created(location).body(responseDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        Bettor currentBettor = principal.getBettor();
+
+        betService.delete(id, currentBettor);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/BetRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/BetRepository.java
@@ -1,7 +1,11 @@
 package io.github.joaomnz.bettracker.repository;
 
 import io.github.joaomnz.bettracker.model.Bet;
+import io.github.joaomnz.bettracker.model.Bettor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BetRepository extends JpaRepository<Bet, Long> {
+    Optional<Bet> findByIdAndBettor(Long id, Bettor bettor);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -35,6 +35,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.POST, "/api/v1/sports/{sportId}/competitions").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/bookmakers/{bookmakerId}/transactions").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/bets").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/bets/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BetService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BetService.java
@@ -1,6 +1,7 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.bet.CreateBetRequestDTO;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.*;
 import io.github.joaomnz.bettracker.model.enums.BetStatus;
 import io.github.joaomnz.bettracker.model.enums.StakeType;
@@ -42,5 +43,15 @@ public class BetService {
         newBet.setCompetition(associatedCompetition);
 
         return betRepository.save(newBet);
+    }
+
+    public void delete(Long id, Bettor currentBettor){
+        Bet bet = findByIdAndBettor(id, currentBettor);
+        betRepository.delete(bet);
+    }
+
+    public Bet findByIdAndBettor(Long id, Bettor currentBettor){
+        return betRepository.findByIdAndBettor(id, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Bet not found with id " + id + " for this bettor."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
@@ -22,8 +22,8 @@ public class BookmakerService {
         return bookmakerRepository.save(newBookmaker);
     }
 
-    public Bookmaker findByIdAndBettor(Long bookmakerId, Bettor currentBettor){
-        return bookmakerRepository.findByIdAndBettor(bookmakerId, currentBettor)
-                .orElseThrow(() -> new ResourceNotFoundException("Bookmaker not found with id " + bookmakerId + " for this bettor."));
+    public Bookmaker findByIdAndBettor(Long id, Bettor currentBettor){
+        return bookmakerRepository.findByIdAndBettor(id, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Bookmaker not found with id " + id + " for this bettor."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
@@ -23,8 +23,8 @@ public class CompetitionService {
         return competitionRepository.save(newCompetition);
     }
 
-    public Competition findByIdAndSport(Long competitionId, Sport parentSport){
-        return competitionRepository.findByIdAndSport(competitionId, parentSport)
-                .orElseThrow(() -> new ResourceNotFoundException("Competition not found with id " + competitionId + " for this sport."));
+    public Competition findByIdAndSport(Long id, Sport parentSport){
+        return competitionRepository.findByIdAndSport(id, parentSport)
+                .orElseThrow(() -> new ResourceNotFoundException("Competition not found with id " + id + " for this sport."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
@@ -22,8 +22,8 @@ public class SportService {
         return sportRepository.save(newSport);
     }
 
-    public Sport findByIdAndBettor(Long sportId, Bettor currentBettor){
-        return sportRepository.findByIdAndBettor(sportId, currentBettor)
-                .orElseThrow(() -> new ResourceNotFoundException("Sport not found with id " + sportId + " for this bettor."));
+    public Sport findByIdAndBettor(Long id, Bettor currentBettor){
+        return sportRepository.findByIdAndBettor(id, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Sport not found with id " + id + " for this bettor."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TipsterService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TipsterService.java
@@ -22,8 +22,8 @@ public class TipsterService {
         return tipsterRepository.save(newTipster);
     }
 
-    public Tipster findByIdAndBettor(Long tipsterId, Bettor curentBettor){
-        return tipsterRepository.findByIdAndBettor(tipsterId, curentBettor)
-                .orElseThrow(() -> new ResourceNotFoundException("Tipster not found with id " + tipsterId + " for this bettor."));
+    public Tipster findByIdAndBettor(Long id, Bettor curentBettor){
+        return tipsterRepository.findByIdAndBettor(id, curentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Tipster not found with id " + id + " for this bettor."));
     }
 }


### PR DESCRIPTION
### Problem Description

This pull request introduces the functionality for an authenticated user to delete their own bet records. This is a crucial part of the CRUD lifecycle for the `Bet` entity.

The implementation includes a critical security check in the service layer to ensure that a user can only delete bets that they own, preventing unauthorized modifications.

### Changes Made

-   [x] **Service (`BetService`):** Implemented a `delete(Long betId, Bettor currentBettor)` method. This method first verifies the bet's ownership before proceeding with the deletion.
-   [x] **Controller (`BetController`):** Created the `DELETE /api/v1/bets/{id}` endpoint.
-   [x] **Response Handling:** The endpoint correctly returns a `204 No Content` status upon successful deletion, following RESTful best practices.
-   [x] **Security:** Added the necessary authorization rule for the new `DELETE` endpoint in `SecurityConfiguration`.
-   [x] **Testing:** Added integration tests to `BetControllerIT.java` to cover two key scenarios:
    -   A user successfully deleting their own bet.
    -   A user being blocked (receiving a `404 Not Found`) when attempting to delete a bet owned by another user.

Closes #22