### PR TITLE
feat: Implement full CRUD for Bookmaker entity

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
@@ -78,6 +78,19 @@ public class BookmakerController {
         return ResponseEntity.created(location).body(responseDTO);
     }
 
+    @PutMapping("/{id}")
+    public ResponseEntity<BookmakerResponseDTO> update(@PathVariable Long id,
+                                                       @Valid @RequestBody BookmakerRequestDTO request,
+                                                       Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Bookmaker updatedBookmaker = bookmakerService.update(id, request, currentBettor);
+
+        BookmakerResponseDTO responseDTO = bookmakerMapper.toDto(updatedBookmaker);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
     private Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
@@ -2,28 +2,65 @@ package io.github.joaomnz.bettracker.controller;
 
 import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
 import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
+import io.github.joaomnz.bettracker.mapper.BookmakerMapper;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.security.BettorDetails;
 import io.github.joaomnz.bettracker.service.BookmakerService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RequestMapping("/api/v1/bookmakers")
 @RestController
 public class BookmakerController {
     private final BookmakerService bookmakerService;
+    private final BookmakerMapper bookmakerMapper;
 
-    public BookmakerController(BookmakerService bookmakerService) {
+    public BookmakerController(BookmakerService bookmakerService, BookmakerMapper bookmakerMapper) {
         this.bookmakerService = bookmakerService;
+        this.bookmakerMapper = bookmakerMapper;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BookmakerResponseDTO> findById(@PathVariable Long id, Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Bookmaker foundBookmaker = bookmakerService.findByIdAndBettor(id, currentBettor);
+
+        BookmakerResponseDTO responseDTO = bookmakerMapper.toDto(foundBookmaker);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO<BookmakerResponseDTO>> findAll(Authentication authentication, Pageable pageable){
+        Bettor currentBettor = getBettor(authentication);
+
+        Page<Bookmaker> bookmakerPage = bookmakerService.findAllByBettor(currentBettor, pageable);
+
+        List<BookmakerResponseDTO> bookmakersDTO = bookmakerPage.getContent().stream()
+                .map(bookmakerMapper::toDto)
+                .toList();
+
+        PageResponseDTO<BookmakerResponseDTO> responseDTO = new PageResponseDTO<>(
+                bookmakersDTO,
+                bookmakerPage.getNumber(),
+                bookmakerPage.getSize(),
+                bookmakerPage.getTotalElements(),
+                bookmakerPage.getTotalPages()
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
     @PostMapping
@@ -39,5 +76,10 @@ public class BookmakerController {
 
         BookmakerResponseDTO responseDTO = new BookmakerResponseDTO(createdBookmaker.getId(), createdBookmaker.getName());
         return ResponseEntity.created(location).body(responseDTO);
+    }
+
+    private Bettor getBettor(Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        return principal.getBettor();
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/BookmakerController.java
@@ -91,6 +91,15 @@ public class BookmakerController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        bookmakerService.delete(id, currentBettor);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     private Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/mapper/BookmakerMapper.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/mapper/BookmakerMapper.java
@@ -1,0 +1,10 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface BookmakerMapper {
+    BookmakerResponseDTO toDto(Bookmaker bookmaker);
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/BookmakerRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/BookmakerRepository.java
@@ -2,10 +2,13 @@ package io.github.joaomnz.bettracker.repository;
 
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface BookmakerRepository extends JpaRepository<Bookmaker, Long> {
     Optional<Bookmaker> findByIdAndBettor(Long bookmakerId, Bettor bettor);
+    Page<Bookmaker> findAllByBettor(Bettor bettor, Pageable pageable);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -45,6 +45,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/tipsters/{id}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{id}").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/bookmakers/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -43,6 +43,8 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/tipsters").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/tipsters/{id}").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/tipsters/{id}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -46,6 +46,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{id}").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/bookmakers/{id}").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/bookmakers/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
@@ -39,4 +39,8 @@ public class BookmakerService {
         return bookmakerRepository.save(bookmakerToUpdate);
     }
 
+    public void delete(Long id, Bettor currentBettor){
+        Bookmaker bookmakerToDelete = findByIdAndBettor(id, currentBettor);
+        bookmakerRepository.delete(bookmakerToDelete);
+    }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
@@ -33,5 +33,10 @@ public class BookmakerService {
         return bookmakerRepository.save(newBookmaker);
     }
 
+    public Bookmaker update(Long id, BookmakerRequestDTO request, Bettor currentBettor){
+        Bookmaker bookmakerToUpdate = findByIdAndBettor(id, currentBettor);
+        bookmakerToUpdate.setName(request.name());
+        return bookmakerRepository.save(bookmakerToUpdate);
+    }
 
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/BookmakerService.java
@@ -5,6 +5,8 @@ import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.repository.BookmakerRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,6 +17,15 @@ public class BookmakerService {
         this.bookmakerRepository = bookmakerRepository;
     }
 
+    public Bookmaker findByIdAndBettor(Long id, Bettor currentBettor){
+        return bookmakerRepository.findByIdAndBettor(id, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Bookmaker not found with id " + id + " for this bettor."));
+    }
+
+    public Page<Bookmaker> findAllByBettor(Bettor currentBettor, Pageable pageable){
+        return bookmakerRepository.findAllByBettor(currentBettor, pageable);
+    }
+
     public Bookmaker create(BookmakerRequestDTO request, Bettor currentBettor){
         Bookmaker newBookmaker = new Bookmaker();
         newBookmaker.setName(request.name());
@@ -22,8 +33,5 @@ public class BookmakerService {
         return bookmakerRepository.save(newBookmaker);
     }
 
-    public Bookmaker findByIdAndBettor(Long id, Bettor currentBettor){
-        return bookmakerRepository.findByIdAndBettor(id, currentBettor)
-                .orElseThrow(() -> new ResourceNotFoundException("Bookmaker not found with id " + id + " for this bettor."));
-    }
+
 }

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/BookmakerControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/BookmakerControllerIT.java
@@ -192,6 +192,48 @@ public class BookmakerControllerIT {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
+    @Test
+    @DisplayName("Should delete a bookmaker when bettor is the owner")
+    void deleteWhenBettorIsOwner() {
+        String token = registerBettorAndGetToken("user.to.delete@email.com");
+        Long bookmakerId = createBookmakerAndGetId(token, "Bookmaker to Delete");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                BOOKMAKER_API_URI + "/" + bookmakerId,
+                HttpMethod.DELETE,
+                httpEntity,
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to delete a bookmaker from another bettor")
+    void deleteWhenBettorIsNotOwner() {
+        String tokenBettorA = registerBettorAndGetToken("bettorA.delete@email.com");
+        Long bookmakerIdBettorA = createBookmakerAndGetId(tokenBettorA, "Bookmaker of A");
+
+        String tokenBettorB = registerBettorAndGetToken("bettorB.delete@email.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenBettorB);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponseDTO> response = testRestTemplate.exchange(
+                BOOKMAKER_API_URI + "/" + bookmakerIdBettorA,
+                HttpMethod.DELETE,
+                httpEntity,
+                ErrorResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
     private String registerBettorAndGetToken(String email) {
         RegisterRequestDTO bettor = new RegisterRequestDTO("João", email, "Password123!");
 

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/BookmakerControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/BookmakerControllerIT.java
@@ -4,11 +4,14 @@ import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
 import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
 import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerRequestDTO;
 import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.dto.shared.ErrorResponseDTO;
+import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -23,10 +26,104 @@ public class BookmakerControllerIT {
     private final String BOOKMAKER_API_URI = "/api/v1/bookmakers";
 
     @Test
+    @DisplayName("Should return a single bookmaker when bettor is the owner")
+    void findByIdWhenBettorIsOwner() {
+        String token = registerBettorAndGetToken("user.get.one@email.com");
+        Long bookmakerId = createBookmakerAndGetId(token, "Bet365");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<BookmakerResponseDTO> response = testRestTemplate.exchange(
+                BOOKMAKER_API_URI + "/" + bookmakerId,
+                HttpMethod.GET,
+                httpEntity,
+                BookmakerResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(bookmakerId);
+        assertThat(response.getBody().name()).isEqualTo("Bet365");
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to get a bookmaker from another bettor")
+    void findByIdWhenBettorIsNotOwner() {
+        String tokenBettorA = registerBettorAndGetToken("bettorA.get@email.com");
+        Long bookmakerIdBettorA = createBookmakerAndGetId(tokenBettorA, "Bookmaker of A");
+
+        String tokenBettorB = registerBettorAndGetToken("bettorB.get@email.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenBettorB);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponseDTO> response = testRestTemplate.exchange(
+                BOOKMAKER_API_URI + "/" + bookmakerIdBettorA,
+                HttpMethod.GET,
+                httpEntity,
+                ErrorResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should return a paginated list of bookmakers for the authenticated bettor")
+    void findAllWhenAuthenticated() {
+        String token = registerBettorAndGetToken("user.get.all@email.com");
+        createBookmakerAndGetId(token, "Betano");
+        createBookmakerAndGetId(token, "Pinnacle");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ParameterizedTypeReference<PageResponseDTO<BookmakerResponseDTO>> responseType = new ParameterizedTypeReference<>() {};
+
+        ResponseEntity<PageResponseDTO<BookmakerResponseDTO>> response = testRestTemplate.exchange(
+                BOOKMAKER_API_URI,
+                HttpMethod.GET,
+                httpEntity,
+                responseType
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content()).hasSize(2);
+        assertThat(response.getBody().totalElements()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Should return an empty list when authenticated bettor has no bookmakers")
+    void findAllWhenAuthenticatedBettorHasNoBookmakers() {
+        String token = registerBettorAndGetToken("user.no.bookmakers@email.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ParameterizedTypeReference<PageResponseDTO<BookmakerResponseDTO>> responseType = new ParameterizedTypeReference<>() {};
+
+        ResponseEntity<PageResponseDTO<BookmakerResponseDTO>> response = testRestTemplate.exchange(
+                BOOKMAKER_API_URI,
+                HttpMethod.GET,
+                httpEntity,
+                responseType
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content()).isEmpty();
+    }
+
+    @Test
     @DisplayName("Should create a bookmaker when authenticated and data is valid")
     void shouldCreateBookmakerWhenAuthenticated() {
         BookmakerRequestDTO newBookmaker = new BookmakerRequestDTO("Bet365");
-        String token = registerBettorAndGetToken();
+        String token = registerBettorAndGetToken("bettorAcreate@gmail.com");
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(token);
         HttpEntity<BookmakerRequestDTO> httpEntity = new HttpEntity<>(newBookmaker, headers);
@@ -48,12 +145,27 @@ public class BookmakerControllerIT {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
-    private String registerBettorAndGetToken() {
-        RegisterRequestDTO bettor = new RegisterRequestDTO("João", "joao.menezes21@Outlook.com", "Password123!");
+    private String registerBettorAndGetToken(String email) {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("João", email, "Password123!");
+
         ResponseEntity<LoginResponseDTO> response =
                 testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody()).isNotNull();
         return response.getBody().token();
+    }
+
+    private Long createBookmakerAndGetId(String token, String name) {
+        BookmakerRequestDTO request = new BookmakerRequestDTO(name);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<BookmakerRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<BookmakerResponseDTO> response =
+                testRestTemplate.exchange(BOOKMAKER_API_URI, HttpMethod.POST, httpEntity, BookmakerResponseDTO.class);
+
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().id();
     }
 }

--- a/backend/src/test/java/io/github/joaomnz/bettracker/mapper/BookmakerMapperTest.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/mapper/BookmakerMapperTest.java
@@ -1,0 +1,32 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.bookmaker.BookmakerResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class BookmakerMapperTest {
+    @Autowired
+    private BookmakerMapper bookmakerMapper;
+
+    @Test
+    @DisplayName("Should correctly map Bookmaker entity to BookmakerResponseDTO")
+    void toDtoShouldMapBookmakerToBookmakerResponseDTO() {
+        Bettor owner = new Bettor();
+        Bookmaker bookmaker = new Bookmaker(1L, "Bet365", owner);
+
+        BookmakerResponseDTO responseDTO = bookmakerMapper.toDto(bookmaker);
+
+        assertThat(responseDTO).isNotNull();
+        assertThat(responseDTO.id()).isEqualTo(1L);
+        assertThat(responseDTO.name()).isEqualTo("Bet365");
+    }
+}


### PR DESCRIPTION
### Problem Description

This pull request completes the full CRUD (Create, Read, Update, Delete) lifecycle for the `Bookmaker` entity, building upon the existing `CREATE` functionality. This allows users to fully manage their list of bookmakers.

All operations are secured with service-layer data ownership checks, ensuring a user can only interact with their own resources. The implementation also introduces a dedicated `BookmakerMapper` to handle data transformations cleanly.

### Changes Made

-   [x] **READ (`GET`):**
    -   Implemented the `GET /api/v1/bookmakers` endpoint to retrieve a paginated list of the user's bookmakers.
    -   Implemented the `GET /api/v1/bookmakers/{id}` endpoint to fetch a single bookmaker by ID, with an ownership check.

-   [x] **UPDATE (`PUT`):**
    -   Implemented the `PUT /api/v1/bookmakers/{id}` endpoint to allow users to update a bookmaker's name.
    -   The service logic verifies ownership before applying the update.

-   [x] **DELETE (`DELETE`):**
    -   Implemented the `DELETE /api/v1/bookmakers/{id}` endpoint, which returns a `204 No Content` status on success after verifying ownership.

-   [x] **Mapper & Unit Tests:**
    -   Created `BookmakerMapper` using MapStruct to handle `Bookmaker` <=> `BookmakerResponseDTO` conversions.
    -   Added a `BookmakerMapperTest` class with unit tests to ensure the mapping logic is correct.

-   [x] **Integration Tests:**
    -   Created and implemented the `BookmakerControllerIT` class with a full suite of integration tests covering all CRUD operations, including success cases, and security scenarios for data ownership.

-   [x] **Security:** Updated `SecurityConfiguration` to protect all new endpoints.

---

Closes #29 