### PR TITLE
feat: Implement full CRUD for Sport entity

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
@@ -93,6 +93,15 @@ public class SportController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id, Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        sportService.delete(id, currentBettor);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     private Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
@@ -1,29 +1,67 @@
 package io.github.joaomnz.bettracker.controller;
 
+import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
 import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
 import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import io.github.joaomnz.bettracker.mapper.SportMapper;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Sport;
 import io.github.joaomnz.bettracker.security.BettorDetails;
 import io.github.joaomnz.bettracker.service.SportService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RequestMapping("/api/v1/sports")
 @RestController
 public class SportController {
     private final SportService sportService;
+    private final SportMapper sportMapper;
 
-    public SportController(SportService sportService) {
+
+    public SportController(SportService sportService, SportMapper sportMapper) {
         this.sportService = sportService;
+        this.sportMapper = sportMapper;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<SportResponseDTO> findById(@PathVariable Long id, Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Sport foundSport = sportService.findByIdAndBettor(id, currentBettor);
+
+        SportResponseDTO responseDTO = sportMapper.toDto(foundSport);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO<SportResponseDTO>> findAll(Authentication authentication, Pageable pageable){
+        Bettor currentBettor = getBettor(authentication);
+
+        Page<Sport> sportPage = sportService.findAllByBettor(currentBettor, pageable);
+
+        List<SportResponseDTO> sportsDTO = sportPage.getContent().stream()
+                .map(sportMapper::toDto)
+                .toList();
+
+        PageResponseDTO<SportResponseDTO> responseDTO = new PageResponseDTO<>(
+                sportsDTO,
+                sportPage.getNumber(),
+                sportPage.getSize(),
+                sportPage.getTotalElements(),
+                sportPage.getTotalPages()
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
     @PostMapping
@@ -40,5 +78,10 @@ public class SportController {
 
         SportResponseDTO responseDTO = new SportResponseDTO(createdSport.getId(), createdSport.getName());
         return ResponseEntity.created(location).body(responseDTO);
+    }
+
+    private Bettor getBettor(Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        return principal.getBettor();
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/SportController.java
@@ -80,6 +80,19 @@ public class SportController {
         return ResponseEntity.created(location).body(responseDTO);
     }
 
+    @PutMapping("/{id}")
+    public ResponseEntity<SportResponseDTO> update(@PathVariable Long id,
+                                                   @Valid @RequestBody SportRequestDTO request,
+                                                   Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Sport updatedSport = sportService.update(id, request, currentBettor);
+
+        SportResponseDTO responseDTO = sportMapper.toDto(updatedSport);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
     private Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/mapper/SportMapper.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/mapper/SportMapper.java
@@ -1,0 +1,10 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import io.github.joaomnz.bettracker.model.Sport;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface SportMapper {
+    SportResponseDTO toDto(Sport sport);
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/SportRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/SportRepository.java
@@ -2,10 +2,13 @@ package io.github.joaomnz.bettracker.repository;
 
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Sport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface SportRepository extends JpaRepository<Sport, Long> {
     Optional<Sport> findByIdAndBettor(Long id, Bettor bettor);
+    Page<Sport> findAllByBettor(Bettor bettor, Pageable pageable);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -50,6 +50,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{id}").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/sports/{id}").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/sports/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -49,6 +49,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/bookmakers/{id}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{id}").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/sports/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -47,6 +47,8 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{id}").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/bookmakers/{id}").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/bookmakers/{id}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sports").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sports/{id}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
@@ -40,4 +40,10 @@ public class SportService {
 
         return sportRepository.save(sportToUpdate);
     }
+
+    public void delete(Long id, Bettor currentBettor){
+        Sport sportToDelete = findByIdAndBettor(id, currentBettor);
+
+        sportRepository.delete(sportToDelete);
+    }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
@@ -5,6 +5,8 @@ import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Sport;
 import io.github.joaomnz.bettracker.repository.SportRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,15 +17,19 @@ public class SportService {
         this.sportRepository = sportRepository;
     }
 
+    public Sport findByIdAndBettor(Long id, Bettor currentBettor){
+        return sportRepository.findByIdAndBettor(id, currentBettor)
+                .orElseThrow(() -> new ResourceNotFoundException("Sport not found with id " + id + " for this bettor."));
+    }
+
+    public Page<Sport> findAllByBettor(Bettor currentBettor, Pageable pageable){
+        return sportRepository.findAllByBettor(currentBettor, pageable);
+    }
+
     public Sport create(SportRequestDTO request, Bettor currentBettor){
         Sport newSport = new Sport();
         newSport.setName(request.name());
         newSport.setBettor(currentBettor);
         return sportRepository.save(newSport);
-    }
-
-    public Sport findByIdAndBettor(Long id, Bettor currentBettor){
-        return sportRepository.findByIdAndBettor(id, currentBettor)
-                .orElseThrow(() -> new ResourceNotFoundException("Sport not found with id " + id + " for this bettor."));
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/SportService.java
@@ -32,4 +32,12 @@ public class SportService {
         newSport.setBettor(currentBettor);
         return sportRepository.save(newSport);
     }
+
+    public Sport update(Long id, SportRequestDTO request, Bettor currentBettor){
+        Sport sportToUpdate = findByIdAndBettor(id, currentBettor);
+
+        sportToUpdate.setName(request.name());
+
+        return sportRepository.save(sportToUpdate);
+    }
 }

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/SportControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/SportControllerIT.java
@@ -2,6 +2,8 @@ package io.github.joaomnz.bettracker.integration;
 
 import io.github.joaomnz.bettracker.dto.auth.LoginResponseDTO;
 import io.github.joaomnz.bettracker.dto.auth.RegisterRequestDTO;
+import io.github.joaomnz.bettracker.dto.shared.ErrorResponseDTO;
+import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
 import io.github.joaomnz.bettracker.dto.sport.SportRequestDTO;
 import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
 import org.junit.jupiter.api.DisplayName;
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -23,10 +26,99 @@ public class SportControllerIT {
     private final String SPORT_API_URI = "/api/v1/sports";
 
     @Test
+    @DisplayName("Should return a single sport when bettor is the owner")
+    void findByIdWhenBettorIsOwner() {
+        String token = registerBettorAndGetToken("user.get.one@email.com");
+        Long sportId = createSportAndGetId(token, "Football");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<SportResponseDTO> response = testRestTemplate.exchange(
+                SPORT_API_URI + "/" + sportId,
+                HttpMethod.GET,
+                httpEntity,
+                SportResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().id()).isEqualTo(sportId);
+        assertThat(response.getBody().name()).isEqualTo("Football");
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to get a sport from another bettor")
+    void findByIdWhenBettorIsNotOwner() {
+        String tokenBettorA = registerBettorAndGetToken("bettorA.get@email.com");
+        Long sportIdBettorA = createSportAndGetId(tokenBettorA, "Sport of A");
+        String tokenBettorB = registerBettorAndGetToken("bettorB.get@email.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenBettorB);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponseDTO> response = testRestTemplate.exchange(
+                SPORT_API_URI + "/" + sportIdBettorA,
+                HttpMethod.GET,
+                httpEntity,
+                ErrorResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Should return a paginated list of sports for the authenticated bettor")
+    void findAllWhenAuthenticated() {
+        String token = registerBettorAndGetToken("user.get.all@email.com");
+        createSportAndGetId(token, "Basketball");
+        createSportAndGetId(token, "Tennis");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+        ParameterizedTypeReference<PageResponseDTO<SportResponseDTO>> responseType = new ParameterizedTypeReference<>() {};
+
+        ResponseEntity<PageResponseDTO<SportResponseDTO>> response = testRestTemplate.exchange(
+                SPORT_API_URI,
+                HttpMethod.GET,
+                httpEntity,
+                responseType
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Should return an empty list when authenticated bettor has no sports")
+    void findAllWhenBettorHasNoSports() {
+        String token = registerBettorAndGetToken("user.no.sports@email.com");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+        ParameterizedTypeReference<PageResponseDTO<SportResponseDTO>> responseType = new ParameterizedTypeReference<>() {};
+
+        ResponseEntity<PageResponseDTO<SportResponseDTO>> response = testRestTemplate.exchange(
+                SPORT_API_URI,
+                HttpMethod.GET,
+                httpEntity,
+                responseType
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().content()).isEmpty();
+    }
+
+    @Test
     @DisplayName("Should create a sport when authenticated and data is valid")
     void shouldCreateSportWhenAuthenticated() {
         SportRequestDTO newSport = new SportRequestDTO("Football");
-        String token = registerBettorAndGetToken();
+        String token = registerBettorAndGetToken("betor.to.create@email.com");
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(token);
         HttpEntity<SportRequestDTO> httpEntity = new HttpEntity<>(newSport, headers);
@@ -48,12 +140,27 @@ public class SportControllerIT {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
-    private String registerBettorAndGetToken() {
-        RegisterRequestDTO bettor = new RegisterRequestDTO("João", "joao.menezes21@Outlook.com", "Password123!");
+    private String registerBettorAndGetToken(String email) {
+        RegisterRequestDTO bettor = new RegisterRequestDTO("João", email, "Password123!");
+
         ResponseEntity<LoginResponseDTO> response =
                 testRestTemplate.postForEntity("/api/v1/users/register", bettor, LoginResponseDTO.class);
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         assertThat(response.getBody()).isNotNull();
         return response.getBody().token();
+    }
+
+    private Long createSportAndGetId(String token, String name) {
+        SportRequestDTO request = new SportRequestDTO(name);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<SportRequestDTO> httpEntity = new HttpEntity<>(request, headers);
+
+        ResponseEntity<SportResponseDTO> response =
+                testRestTemplate.exchange(SPORT_API_URI, HttpMethod.POST, httpEntity, SportResponseDTO.class);
+
+        assertThat(response.getBody()).isNotNull();
+        return response.getBody().id();
     }
 }

--- a/backend/src/test/java/io/github/joaomnz/bettracker/integration/SportControllerIT.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/integration/SportControllerIT.java
@@ -187,6 +187,48 @@ public class SportControllerIT {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
+    @Test
+    @DisplayName("Should delete a sport when bettor is the owner")
+    void deleteWhenBettorIsOwner() {
+        String token = registerBettorAndGetToken("user.to.delete@email.com");
+        Long sportId = createSportAndGetId(token, "Sport to Delete");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<Void> response = testRestTemplate.exchange(
+                SPORT_API_URI + "/" + sportId,
+                HttpMethod.DELETE,
+                httpEntity,
+                Void.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    @DisplayName("Should return 404 Not Found when trying to delete a sport from another bettor")
+    void deleteWhenBettorIsNotOwner() {
+        String tokenBettorA = registerBettorAndGetToken("bettorA.delete@email.com");
+        Long sportIdBettorA = createSportAndGetId(tokenBettorA, "Sport of A");
+
+        String tokenBettorB = registerBettorAndGetToken("bettorB.delete@email.com");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tokenBettorB);
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+
+        ResponseEntity<ErrorResponseDTO> response = testRestTemplate.exchange(
+                SPORT_API_URI + "/" + sportIdBettorA,
+                HttpMethod.DELETE,
+                httpEntity,
+                ErrorResponseDTO.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
     private String registerBettorAndGetToken(String email) {
         RegisterRequestDTO bettor = new RegisterRequestDTO("João", email, "Password123!");
 

--- a/backend/src/test/java/io/github/joaomnz/bettracker/mapper/SportMapperTest.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/mapper/SportMapperTest.java
@@ -1,0 +1,32 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.sport.SportResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Sport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class SportMapperTest {
+    @Autowired
+    private SportMapper sportMapper;
+
+    @Test
+    @DisplayName("Should correctly map Sport entity to SportResponseDTO")
+    void toDtoShouldMapSportToSportResponseDTO() {
+        Bettor owner = new Bettor();
+        Sport sport = new Sport(1L, "Football", owner);
+
+        SportResponseDTO responseDTO = sportMapper.toDto(sport);
+
+        assertThat(responseDTO).isNotNull();
+        assertThat(responseDTO.id()).isEqualTo(1L);
+        assertThat(responseDTO.name()).isEqualTo("Football");
+    }
+}


### PR DESCRIPTION
### Problem Description

This pull request completes the full CRUD (Create, Read, Update, Delete) lifecycle for the `Sport` entity, building upon the existing `CREATE` functionality. This allows users to fully manage their list of sports.

All operations are secured with service-layer data ownership checks, ensuring a user can only interact with their own resources. The implementation also introduces a dedicated `SportMapper` to handle data transformations cleanly.

### Changes Made

-   [x] **READ (`GET`):**
    -   Implemented the `GET /api/v1/sports` endpoint to retrieve a paginated list of the user's sports.
    -   Implemented the `GET /api/v1/sports/{id}` endpoint to fetch a single sport by ID, with an ownership check.

-   [x] **UPDATE (`PUT`):**
    -   Implemented the `PUT /api/v1/sports/{id}` endpoint to allow users to update a sport's name.
    -   The service logic verifies ownership before applying the update.

-   [x] **DELETE (`DELETE`):**
    -   Implemented the `DELETE /api/v1/sports/{id}` endpoint, which returns a `204 No Content` status on success after verifying ownership.

-   [x] **Mapper & Unit Tests:**
    -   Created `SportMapper` using MapStruct to handle `Sport` <=> `SportResponseDTO` conversions.
    -   Added a `SportMapperTest` class with unit tests to ensure the mapping logic is correct.

-   [x] **Integration Tests:**
    -   Created and implemented the `SportControllerIT` class with a full suite of integration tests covering all CRUD operations, including success cases, and security scenarios for data ownership.

-   [x] **Security:** Updated `SecurityConfiguration` to protect all new endpoints.


---

Closes #31 