### PR TITLE
feat: Implement full CRUD for Competition entity

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
@@ -2,6 +2,8 @@ package io.github.joaomnz.bettracker.controller;
 
 import io.github.joaomnz.bettracker.dto.competition.CompetitionRequestDTO;
 import io.github.joaomnz.bettracker.dto.competition.CompetitionResponseDTO;
+import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
+import io.github.joaomnz.bettracker.mapper.CompetitionMapper;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Competition;
 import io.github.joaomnz.bettracker.model.Sport;
@@ -9,30 +11,73 @@ import io.github.joaomnz.bettracker.security.BettorDetails;
 import io.github.joaomnz.bettracker.service.CompetitionService;
 import io.github.joaomnz.bettracker.service.SportService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RequestMapping("/api/v1/sports/{sportId}/competitions")
 @RestController
 public class CompetitionController {
     private final CompetitionService competitionService;
     private final SportService sportService;
+    private final CompetitionMapper competitionMapper;
 
-    public CompetitionController(CompetitionService competitionService, SportService sportService) {
+    public CompetitionController(CompetitionService competitionService, SportService sportService, CompetitionMapper competitionMapper) {
         this.competitionService = competitionService;
         this.sportService = sportService;
+        this.competitionMapper = competitionMapper;
+    }
+
+    @GetMapping("/{competitionId}")
+    public ResponseEntity<CompetitionResponseDTO> findById(@PathVariable Long sportId,
+                                                           @PathVariable Long competitionId,
+                                                           Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Sport parentSport = sportService.findByIdAndBettor(sportId, currentBettor);
+        Competition foundCompetition = competitionService.findByIdAndSport(competitionId, parentSport);
+
+        CompetitionResponseDTO responseDTO = competitionMapper.toDto(foundCompetition);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO<CompetitionResponseDTO>> findAll(@PathVariable Long sportId,
+                                                                           Authentication authentication,
+                                                                           Pageable pageable){
+        Bettor currentBettor = getBettor(authentication);
+
+        Sport parentSport = sportService.findByIdAndBettor(sportId, currentBettor);
+        Page<Competition> competitionPage = competitionService.findAllBySport(parentSport, pageable);
+
+        List<CompetitionResponseDTO> competitionsDTO = competitionPage.getContent().stream()
+                .map(competitionMapper::toDto)
+                .toList();
+
+        PageResponseDTO<CompetitionResponseDTO> responseDTO = new PageResponseDTO<>(
+                competitionsDTO,
+                competitionPage.getNumber(),
+                competitionPage.getSize(),
+                competitionPage.getTotalElements(),
+                competitionPage.getTotalPages()
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
     @PostMapping
     public ResponseEntity<CompetitionResponseDTO> create(@PathVariable Long sportId,
                                                          @Valid @RequestBody CompetitionRequestDTO request,
                                                          Authentication authentication){
-        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
-        Bettor currentBettor = principal.getBettor();
+        Bettor currentBettor = getBettor(authentication);
         Sport parentSport = sportService.findByIdAndBettor(sportId, currentBettor);
         Competition createdCompetition = competitionService.create(request, parentSport);
 
@@ -44,5 +89,10 @@ public class CompetitionController {
 
         CompetitionResponseDTO responseDTO = new CompetitionResponseDTO(createdCompetition.getId(), createdCompetition.getName());
         return ResponseEntity.created(location).body(responseDTO);
+    }
+
+    public Bettor getBettor(Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        return principal.getBettor();
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
@@ -91,6 +91,21 @@ public class CompetitionController {
         return ResponseEntity.created(location).body(responseDTO);
     }
 
+    @PutMapping("/{competitionId}")
+    public ResponseEntity<CompetitionResponseDTO> update(@PathVariable Long sportId,
+                                                         @PathVariable Long competitionId,
+                                                         @Valid @RequestBody CompetitionRequestDTO request,
+                                                         Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Sport parentSport = sportService.findByIdAndBettor(sportId, currentBettor);
+        Competition updatedCompetition = competitionService.update(competitionId, request, parentSport);
+
+        CompetitionResponseDTO responseDTO = competitionMapper.toDto(updatedCompetition);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
     public Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/CompetitionController.java
@@ -106,6 +106,18 @@ public class CompetitionController {
         return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
+    @DeleteMapping("/{competitionId}")
+    public ResponseEntity<Void> delete(@PathVariable Long sportId,
+                                       @PathVariable Long competitionId,
+                                       Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Sport parentSport = sportService.findByIdAndBettor(sportId, currentBettor);
+        competitionService.delete(competitionId, parentSport);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     public Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/mapper/CompetitionMapper.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/mapper/CompetitionMapper.java
@@ -1,0 +1,10 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.competition.CompetitionResponseDTO;
+import io.github.joaomnz.bettracker.model.Competition;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CompetitionMapper {
+    CompetitionResponseDTO toDto(Competition competition);
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/CompetitionRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/CompetitionRepository.java
@@ -2,10 +2,13 @@ package io.github.joaomnz.bettracker.repository;
 
 import io.github.joaomnz.bettracker.model.Competition;
 import io.github.joaomnz.bettracker.model.Sport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CompetitionRepository extends JpaRepository<Competition, Long> {
     Optional<Competition> findByIdAndSport(Long id, Sport sport);
+    Page<Competition> findAllBySport(Sport sport, Pageable pageable);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -54,6 +54,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -51,6 +51,8 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{id}").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/sports/{id}").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/sports/{id}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -53,6 +53,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/sports/{id}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions").authenticated()
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
@@ -34,5 +34,9 @@ public class CompetitionService {
         return competitionRepository.save(newCompetition);
     }
 
-
+    public Competition update(Long id, CompetitionRequestDTO request, Sport parentSport){
+        Competition competitionToUpdate = findByIdAndSport(id, parentSport);
+        competitionToUpdate.setName(request.name());
+        return competitionRepository.save(competitionToUpdate);
+    }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
@@ -39,4 +39,9 @@ public class CompetitionService {
         competitionToUpdate.setName(request.name());
         return competitionRepository.save(competitionToUpdate);
     }
+
+    public void delete(Long id, Sport parentSport){
+        Competition competitionToDelete = findByIdAndSport(id, parentSport);
+        competitionRepository.delete(competitionToDelete);
+    }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/CompetitionService.java
@@ -5,6 +5,8 @@ import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Competition;
 import io.github.joaomnz.bettracker.model.Sport;
 import io.github.joaomnz.bettracker.repository.CompetitionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,6 +17,15 @@ public class CompetitionService {
         this.competitionRepository = competitionRepository;
     }
 
+    public Competition findByIdAndSport(Long id, Sport parentSport){
+        return competitionRepository.findByIdAndSport(id, parentSport)
+                .orElseThrow(() -> new ResourceNotFoundException("Competition not found with id " + id + " for this sport."));
+    }
+
+    public Page<Competition> findAllBySport(Sport parentSport, Pageable pageable){
+        return competitionRepository.findAllBySport(parentSport, pageable);
+    }
+
     public Competition create(CompetitionRequestDTO request, Sport parentSport){
         Competition newCompetition = new Competition();
         newCompetition.setName(request.name());
@@ -23,8 +34,5 @@ public class CompetitionService {
         return competitionRepository.save(newCompetition);
     }
 
-    public Competition findByIdAndSport(Long id, Sport parentSport){
-        return competitionRepository.findByIdAndSport(id, parentSport)
-                .orElseThrow(() -> new ResourceNotFoundException("Competition not found with id " + id + " for this sport."));
-    }
+
 }

--- a/backend/src/test/java/io/github/joaomnz/bettracker/mapper/CompetitionMapperTest.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/mapper/CompetitionMapperTest.java
@@ -1,0 +1,34 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.competition.CompetitionResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Competition;
+import io.github.joaomnz.bettracker.model.Sport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class CompetitionMapperTest {
+    @Autowired
+    private CompetitionMapper competitionMapper;
+
+    @Test
+    @DisplayName("Should correctly map Competition entity to CompetitionResponseDTO")
+    void toDtoShouldMapCompetitionToCompetitionResponseDTO() {
+        Bettor owner = new Bettor();
+        Sport parentSport = new Sport(1L, "Football", owner);
+        Competition competition = new Competition(10L, "Premier League", owner, parentSport);
+
+        CompetitionResponseDTO responseDTO = competitionMapper.toDto(competition);
+
+        assertThat(responseDTO).isNotNull();
+        assertThat(responseDTO.id()).isEqualTo(10L);
+        assertThat(responseDTO.name()).isEqualTo("Premier League");
+    }
+}


### PR DESCRIPTION
### Problem Description

This pull request completes the full CRUD (Create, Read, Update, Delete) lifecycle for the `Competition` entity, which is managed as a nested resource under `Sport`. This allows users to fully manage the competitions associated with each of their sports.

A key aspect of this implementation is the security model for nested resources. All operations first verify that the user owns the parent `Sport` before proceeding, ensuring a user cannot interact with competitions belonging to another user's sport.

### Changes Made

-   [x] **READ (`GET`):**
    -   Implemented `GET /api/v1/sports/{sportId}/competitions` to retrieve a paginated list of a sport's competitions.
    -   Implemented `GET /api/v1/sports/{sportId}/competitions/{competitionId}` to fetch a single competition, validating ownership of the parent sport.

-   [x] **UPDATE (`PUT`):**
    -   Implemented `PUT /api/v1/sports/{sportId}/competitions/{competitionId}` to allow users to update a competition's name.
    -   The service logic verifies ownership of the parent `Sport` before applying the update.

-   [x] **DELETE (`DELETE`):**
    -   Implemented `DELETE /api/v1/sports/{sportId}/competitions/{competitionId}`, which returns a `204 No Content` status on success after verifying ownership.

-   [x] **Mapper & Unit Tests:**
    -   Created `CompetitionMapper` using MapStruct to handle `Competition` <=> `CompetitionResponseDTO` conversions.
    -   Added a `CompetitionMapperTest` class with unit tests to ensure the mapping logic is correct.

-   [x] **Integration Tests:**
    -   Created and implemented the `CompetitionControllerIT` class with a full suite of integration tests covering all CRUD operations.
    -   Tests include success cases and critical security scenarios, such as a user trying to access a competition via another user's sport.

-   [x] **Security:** Updated `SecurityConfiguration` to protect all new nested endpoints.

---

Closes #33 
