### PR TITLE
feat: Implement full CRUD for Transaction entity

### DIFF
--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
@@ -97,6 +97,18 @@ public class TransactionController {
         return ResponseEntity.created(location).body(responseDTO);
     }
 
+    @DeleteMapping("/{transactionId}")
+    public ResponseEntity<Void> delete(@PathVariable Long bookmakerId,
+                                       @PathVariable Long transactionId,
+                                       Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Bookmaker parentBookmaker = bookmakerService.findByIdAndBettor(bookmakerId, currentBettor);
+        transactionService.delete(transactionId, parentBookmaker);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     public Bettor getBettor(Authentication authentication){
         BettorDetails principal = (BettorDetails) authentication.getPrincipal();
         return principal.getBettor();

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
@@ -1,7 +1,9 @@
 package io.github.joaomnz.bettracker.controller;
 
+import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
 import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
 import io.github.joaomnz.bettracker.dto.transaction.TransactionResponseDTO;
+import io.github.joaomnz.bettracker.mapper.TransactionMapper;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.model.Transaction;
@@ -9,22 +11,67 @@ import io.github.joaomnz.bettracker.security.BettorDetails;
 import io.github.joaomnz.bettracker.service.BookmakerService;
 import io.github.joaomnz.bettracker.service.TransactionService;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpRange;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @RequestMapping("/api/v1/bookmakers/{bookmakerId}/transactions")
 @RestController
 public class TransactionController {
     private final TransactionService transactionService;
     private final BookmakerService bookmakerService;
+    private final TransactionMapper transactionMapper;
 
-    public TransactionController(TransactionService transactionService, BookmakerService bookmakerService) {
+    public TransactionController(TransactionService transactionService, BookmakerService bookmakerService, TransactionMapper transactionMapper) {
         this.transactionService = transactionService;
         this.bookmakerService = bookmakerService;
+        this.transactionMapper = transactionMapper;
+    }
+
+    @GetMapping("/{transactionId}")
+    public ResponseEntity<TransactionResponseDTO> findById(@PathVariable Long bookmakerId,
+                                                           @PathVariable Long transactionId,
+                                                           Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Bookmaker parentBookmaker = bookmakerService.findByIdAndBettor(bookmakerId, currentBettor);
+        Transaction foundTransaction = transactionService.findByIdAndBookmaker(transactionId, parentBookmaker);
+
+        TransactionResponseDTO responseDTO = transactionMapper.toDto(foundTransaction);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponseDTO<TransactionResponseDTO>> findAll(@PathVariable Long bookmakerId,
+                                                                           Authentication authentication,
+                                                                           Pageable pageable){
+        Bettor currentBettor = getBettor(authentication);
+
+        Bookmaker parentBookmaker = bookmakerService.findByIdAndBettor(bookmakerId, currentBettor);
+        Page<Transaction> transactionPage = transactionService.findAllByBookmaker(parentBookmaker, pageable);
+
+        List<TransactionResponseDTO> transactionsDTO = transactionPage.getContent().stream()
+                .map(transactionMapper::toDto)
+                .toList();
+
+        PageResponseDTO<TransactionResponseDTO> responseDTO = new PageResponseDTO<>(
+                transactionsDTO,
+                transactionPage.getNumber(),
+                transactionPage.getSize(),
+                transactionPage.getTotalElements(),
+                transactionPage.getTotalPages()
+        );
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
     @PostMapping
@@ -48,5 +95,10 @@ public class TransactionController {
                 createdTransaction.getType(),
                 createdTransaction.getCreatedAt());
         return ResponseEntity.created(location).body(responseDTO);
+    }
+
+    public Bettor getBettor(Authentication authentication){
+        BettorDetails principal = (BettorDetails) authentication.getPrincipal();
+        return principal.getBettor();
     }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/controller/TransactionController.java
@@ -3,6 +3,7 @@ package io.github.joaomnz.bettracker.controller;
 import io.github.joaomnz.bettracker.dto.shared.PageResponseDTO;
 import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
 import io.github.joaomnz.bettracker.dto.transaction.TransactionResponseDTO;
+import io.github.joaomnz.bettracker.dto.transaction.UpdateTransactionRequestDTO;
 import io.github.joaomnz.bettracker.mapper.TransactionMapper;
 import io.github.joaomnz.bettracker.model.Bettor;
 import io.github.joaomnz.bettracker.model.Bookmaker;
@@ -107,6 +108,21 @@ public class TransactionController {
         transactionService.delete(transactionId, parentBookmaker);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PatchMapping("/{transactionId}")
+    public ResponseEntity<TransactionResponseDTO> update(@PathVariable Long bookmakerId,
+                                                         @PathVariable Long transactionId,
+                                                         @Valid @RequestBody UpdateTransactionRequestDTO request,
+                                                         Authentication authentication){
+        Bettor currentBettor = getBettor(authentication);
+
+        Bookmaker parentBookmaker = bookmakerService.findByIdAndBettor(bookmakerId, currentBettor);
+        Transaction updatedTransaction = transactionService.update(transactionId, request, parentBookmaker);
+
+        TransactionResponseDTO responseDTO = transactionMapper.toDto(updatedTransaction);
+
+        return ResponseEntity.status(HttpStatus.OK).body(responseDTO);
     }
 
     public Bettor getBettor(Authentication authentication){

--- a/backend/src/main/java/io/github/joaomnz/bettracker/dto/transaction/UpdateTransactionRequestDTO.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/dto/transaction/UpdateTransactionRequestDTO.java
@@ -1,0 +1,13 @@
+package io.github.joaomnz.bettracker.dto.transaction;
+
+import io.github.joaomnz.bettracker.model.enums.TransactionType;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public record UpdateTransactionRequestDTO(
+        @Positive(message = "Amount must be positive.")
+        BigDecimal amount,
+
+        TransactionType type
+) {}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/mapper/TransactionMapper.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/mapper/TransactionMapper.java
@@ -1,0 +1,10 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.transaction.TransactionResponseDTO;
+import io.github.joaomnz.bettracker.model.Transaction;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface TransactionMapper {
+    TransactionResponseDTO toDto(Transaction transaction);
+}

--- a/backend/src/main/java/io/github/joaomnz/bettracker/repository/TransactionRepository.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/repository/TransactionRepository.java
@@ -1,7 +1,14 @@
 package io.github.joaomnz.bettracker.repository;
 
+import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.model.Transaction;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+    Optional<Transaction> findByIdAndBookmaker(Long id, Bookmaker bookmaker);
+    Page<Transaction> findAllByBookmaker(Bookmaker bookmaker, Pageable pageable);
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -55,6 +55,8 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/sports/{sportId}/competitions").authenticated()
                         .requestMatchers(HttpMethod.PUT, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{bookmakerId}/transactions").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -58,6 +58,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{bookmakerId}/transactions").authenticated()
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/security/SecurityConfiguration.java
@@ -57,6 +57,7 @@ public class SecurityConfiguration {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/sports/{sportId}/competitions/{competitionId}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/bookmakers/{bookmakerId}/transactions").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}").authenticated()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(bettorAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
@@ -34,4 +34,10 @@ public class TransactionService {
         newTransaction.setBettor(parentBookmaker.getBettor());
         return  transactionRepository.save(newTransaction);
     }
+
+    public void delete(Long transactionId, Bookmaker bookmaker){
+        Transaction transactionToDelete = findByIdAndBookmaker(transactionId, bookmaker);
+
+        transactionRepository.delete(transactionToDelete);
+    }
 }

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
@@ -1,6 +1,7 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
+import io.github.joaomnz.bettracker.dto.transaction.UpdateTransactionRequestDTO;
 import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.model.Transaction;
@@ -33,6 +34,19 @@ public class TransactionService {
         newTransaction.setBookmaker(parentBookmaker);
         newTransaction.setBettor(parentBookmaker.getBettor());
         return  transactionRepository.save(newTransaction);
+    }
+
+    public Transaction update(Long id, UpdateTransactionRequestDTO request, Bookmaker parentBookmaker){
+        Transaction transactionToUpdate = findByIdAndBookmaker(id, parentBookmaker);
+
+        if (request.amount() != null) {
+            transactionToUpdate.setAmount(request.amount());
+        }
+        if (request.type() != null) {
+            transactionToUpdate.setType(request.type());
+        }
+
+        return transactionRepository.save(transactionToUpdate);
     }
 
     public void delete(Long transactionId, Bookmaker bookmaker){

--- a/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
+++ b/backend/src/main/java/io/github/joaomnz/bettracker/service/TransactionService.java
@@ -1,9 +1,12 @@
 package io.github.joaomnz.bettracker.service;
 
 import io.github.joaomnz.bettracker.dto.transaction.TransactionRequestDTO;
+import io.github.joaomnz.bettracker.exceptions.ResourceNotFoundException;
 import io.github.joaomnz.bettracker.model.Bookmaker;
 import io.github.joaomnz.bettracker.model.Transaction;
 import io.github.joaomnz.bettracker.repository.TransactionRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,6 +15,15 @@ public class TransactionService {
 
     public TransactionService(TransactionRepository transactionRepository) {
         this.transactionRepository = transactionRepository;
+    }
+
+    public Transaction findByIdAndBookmaker(Long id, Bookmaker parentBookmaker){
+        return transactionRepository.findByIdAndBookmaker(id, parentBookmaker)
+                .orElseThrow(() -> new ResourceNotFoundException("Transaction not found with id " + id + " for this bookmaker."));
+    }
+
+    public Page<Transaction> findAllByBookmaker(Bookmaker parentBookmaker, Pageable pageable){
+        return transactionRepository.findAllByBookmaker(parentBookmaker, pageable);
     }
 
     public Transaction create(TransactionRequestDTO request, Bookmaker parentBookmaker){

--- a/backend/src/test/java/io/github/joaomnz/bettracker/mapper/TransactionMapperTest.java
+++ b/backend/src/test/java/io/github/joaomnz/bettracker/mapper/TransactionMapperTest.java
@@ -1,0 +1,48 @@
+package io.github.joaomnz.bettracker.mapper;
+
+import io.github.joaomnz.bettracker.dto.transaction.TransactionResponseDTO;
+import io.github.joaomnz.bettracker.model.Bettor;
+import io.github.joaomnz.bettracker.model.Bookmaker;
+import io.github.joaomnz.bettracker.model.Transaction;
+import io.github.joaomnz.bettracker.model.enums.TransactionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class TransactionMapperTest {
+
+    @Autowired
+    private TransactionMapper transactionMapper;
+
+    @Test
+    @DisplayName("Should correctly map Transaction entity to TransactionResponseDTO")
+    void toDtoShouldMapTransactionToTransactionResponseDTO() {
+        Bettor owner = new Bettor();
+        Bookmaker parentBookmaker = new Bookmaker(1L, "Bet365", owner);
+        Transaction transaction = new Transaction();
+        transaction.setId(50L);
+        transaction.setAmount(new BigDecimal("150.75"));
+        transaction.setType(TransactionType.DEPOSIT);
+
+        transaction.setCreatedAt(LocalDateTime.now());
+        transaction.setBettor(owner);
+        transaction.setBookmaker(parentBookmaker);
+
+        TransactionResponseDTO responseDTO = transactionMapper.toDto(transaction);
+
+        assertThat(responseDTO).isNotNull();
+        assertThat(responseDTO.id()).isEqualTo(50L);
+        assertThat(responseDTO.amount()).isEqualTo(new BigDecimal("150.75"));
+        assertThat(responseDTO.type()).isEqualTo(TransactionType.DEPOSIT);
+        assertThat(responseDTO.createdAt()).isEqualTo(transaction.getCreatedAt());
+    }
+}


### PR DESCRIPTION
### Problem Description

This pull request completes the full CRUD (Create, Read, Update, Delete) lifecycle for the `Transaction` entity, which is managed as a nested resource under `Bookmaker`. This allows users to fully manage the financial transactions associated with each of their bookmakers.

All operations are secured, ensuring a user can only interact with transactions belonging to a bookmaker that they own. The implementation also introduces a dedicated `TransactionMapper` for clean data transformation.

### Changes Made

-   [x] **READ (`GET`):**
    -   Implemented `GET /api/v1/bookmakers/{bookmakerId}/transactions` to retrieve a paginated list of a bookmaker's transactions.
    -   Implemented `GET /api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}` to fetch a single transaction, validating ownership of the parent bookmaker.

-   [x] **UPDATE (`PATCH`):**
    -   Implemented `PATCH /api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}` to allow users to partially update a transaction's details (e.g., `amount`, `type`).
    -   The service logic verifies ownership of the parent `Bookmaker` before applying the update.

-   [x] **DELETE (`DELETE`):**
    -   Implemented `DELETE /api/v1/bookmakers/{bookmakerId}/transactions/{transactionId}`, which returns a `204 No Content` status on success after verifying ownership.

-   [x] **Mapper & Unit Tests:**
    -   Created `TransactionMapper` using MapStruct to handle `Transaction` <=> `TransactionResponseDTO` conversions.
    -   Added a `TransactionMapperTest` class with unit tests to ensure the mapping logic is correct.

-   [x] **Integration Tests:**
    -   Created and implemented the `TransactionControllerIT` class with a full suite of integration tests covering all CRUD operations.
    -   Tests include success cases and critical security scenarios, such as a user trying to access a transaction via another user's bookmaker.

-   [x] **Security:** Updated `SecurityConfiguration` to protect all new nested endpoints.

---

Closes #35 